### PR TITLE
Parameterised environments in relevant notebooks as workflow failed.

### DIFF
--- a/Databricks/ARCHIVE/BAIL/AUDIT/Bails_Receive_Audit_Dashboard.ipynb
+++ b/Databricks/ARCHIVE/BAIL/AUDIT/Bails_Receive_Audit_Dashboard.ipynb
@@ -34,7 +34,46 @@
    },
    "outputs": [],
    "source": [
-    "df_create_record_data = spark.read.format(\"delta\").load(\"abfss://silver@ingest00curatedsbox.dfs.core.windows.net/ARIADM/ARM/response/BAILS/create_record/\")\n",
+    "config = spark.read.option(\"multiline\", \"true\").json(\"dbfs:/configs/config.json\")\n",
+    "env = config.first()[\"env\"].strip().lower()\n",
+    "lz_key = config.first()[\"lz_key\"].strip().lower()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "8411ef5a-560c-4ce7-b118-7a55500f7505",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "curated_storage_account = f\"ingest{env}curatedsbox\"\n",
+    "silver_container = \"silver\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "ceffd596-ba71-42f0-a74d-dec55d936251",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df_create_record_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/response/BAILS/create_record/\")\n",
     "df_create_record_data.createOrReplaceTempView(\"bails_create_record\")"
    ]
   },
@@ -360,7 +399,7 @@
    },
    "outputs": [],
    "source": [
-    "df_input_upload_data = spark.read.format(\"delta\").load(\"abfss://silver@ingest00curatedsbox.dfs.core.windows.net/ARIADM/ARM/response/BAILS/input_upload/\")\n",
+    "df_input_upload_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/response/BAILS/input_upload/\")\n",
     "df_input_upload_data.createOrReplaceTempView(\"bails_input_upload\")"
    ]
   },
@@ -546,7 +585,7 @@
    },
    "outputs": [],
    "source": [
-    "df_upload_file_data = spark.read.format(\"delta\").load(\"abfss://silver@ingest00curatedsbox.dfs.core.windows.net/ARIADM/ARM/response/BAILS/upload_file/\")\n",
+    "df_upload_file_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/response/BAILS/upload_file/\")\n",
     "df_upload_file_data.createOrReplaceTempView(\"bails_upload_file\")"
    ]
   },
@@ -874,7 +913,7 @@
    },
    "outputs": [],
    "source": [
-    "df_amalgamated_response_data = spark.read.format(\"delta\").load(\"abfss://silver@ingest00curatedsbox.dfs.core.windows.net/ARIADM/ARM/response/BAILS/amalgamated_responses/\")\n",
+    "df_amalgamated_response_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/response/BAILS/amalgamated_responses/\")\n",
     "df_amalgamated_response_data.createOrReplaceTempView(\"bails_amalgamated_response_data\")"
    ]
   },
@@ -1037,7 +1076,7 @@
       "stack": true
      },
      "nuid": "e4d73918-2994-425e-beb4-5256fb9c2250",
-     "origId": 6803213753371965,
+     "origId": 6716476543481128,
      "title": "Bails Receive Audit Dashboard",
      "version": "DashboardViewV1",
      "width": 1024

--- a/Databricks/ARCHIVE/BAIL/AUDIT/Bails_Send_Audit_Dashboard.ipynb
+++ b/Databricks/ARCHIVE/BAIL/AUDIT/Bails_Send_Audit_Dashboard.ipynb
@@ -21,6 +21,45 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "92ccdaf5-65a4-4c6d-8aa3-0f1b68fca66f",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "config = spark.read.option(\"multiline\", \"true\").json(\"dbfs:/configs/config.json\")\n",
+    "env = config.first()[\"env\"].strip().lower()\n",
+    "lz_key = config.first()[\"lz_key\"].strip().lower()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "f33e794c-6fda-4ef0-8727-ca91848cfec5",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "curated_storage_account = f\"ingest{env}curatedsbox\"\n",
+    "silver_container = \"silver\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
       "byteLimit": 2048000,
       "rowLimit": 10000
@@ -34,7 +73,7 @@
    },
    "outputs": [],
    "source": [
-    "df_joh_ack_audit_data = spark.read.format(\"delta\").load(\"abfss://silver@ingest00curatedsbox.dfs.core.windows.net/ARIADM/ARM/AUDIT/BAILS/bails_ack_audit/\")\n",
+    "df_joh_ack_audit_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/BAILS/bails_ack_audit/\")\n",
     "df_joh_ack_audit_data.createOrReplaceTempView(\"bails_acknowledge_audit_data\")"
    ]
   },
@@ -207,7 +246,7 @@
    },
    "outputs": [],
    "source": [
-    "df_joh_created_audit_data = spark.read.format(\"delta\").load(\"abfss://silver@ingest00curatedsbox.dfs.core.windows.net/ARIADM/ARM/AUDIT/BAILS/bl_cr_audit_table/\")\n",
+    "df_joh_created_audit_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/BAILS/bl_cr_audit_table/\")\n",
     "\n",
     "df_joh_created_audit_data.createOrReplaceTempView(\"bl_created_audit_data\")"
    ]
@@ -271,7 +310,7 @@
    },
    "outputs": [],
    "source": [
-    "df_publish_audit_db_eh_audit_data = spark.read.format(\"delta\").load(\"abfss://silver@ingest00curatedsbox.dfs.core.windows.net/ARIADM/ARM/AUDIT/BAILS/publish_audit_db_eh/\")\n",
+    "df_publish_audit_db_eh_audit_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/BAILS/publish_audit_db_eh/\")\n",
     "df_publish_audit_db_eh_audit_data.createOrReplaceTempView(\"bl_publish_audit_db_eh_data\")"
    ]
   },
@@ -476,7 +515,7 @@
       "stack": true
      },
      "nuid": "3a28d7e3-185e-4471-854f-e70490451a21",
-     "origId": 6803213753371907,
+     "origId": 6716476543481143,
      "title": "Bails Send Audit Dashboard",
      "version": "DashboardViewV1",
      "width": 1024

--- a/Databricks/ARCHIVE/BAIL/audit_processing_bails.ipynb
+++ b/Databricks/ARCHIVE/BAIL/audit_processing_bails.ipynb
@@ -136,7 +136,7 @@
    },
    "outputs": [],
    "source": [
-    "curated_storage_account = \"ingest00curatedsbox\"\n",
+    "curated_storage_account = f\"ingest{env}curatedsbox\"\n",
     "\n",
     "silver_curated_container = \"silver\"\n",
     "\n"

--- a/Databricks/ARCHIVE/BAIL/bails_ack_autoloader.ipynb
+++ b/Databricks/ARCHIVE/BAIL/bails_ack_autoloader.ipynb
@@ -323,10 +323,10 @@
    "outputs": [],
    "source": [
     "# Container and path for storing Delta table (in curated storage account)\n",
-    "data_path = \"abfss://silver@ingest00curatedsbox.dfs.core.windows.net/ARIADM/ARM/AUDIT/BAILS/bails_ack_audit\"\n",
+    "data_path = f\"abfss://silver@ingest{env}curatedsbox.dfs.core.windows.net/ARIADM/ARM/AUDIT/BAILS/bails_ack_audit\"\n",
     "\n",
     "# Container and path for checkpoint (in xcuttings storage account)\n",
-    "checkpoint_path = \"abfss://db-ack-checkpoint@ingest00xcuttingsbox.dfs.core.windows.net/ARMBAILS/ACK/ack\"\n"
+    "checkpoint_path = f\"abfss://db-ack-checkpoint@ingest{env}xcuttingsbox.dfs.core.windows.net/ARMBAILS/ACK/ack\"\n"
    ]
   },
   {

--- a/Databricks/ARCHIVE/BAIL/bails_to_eventhubs.ipynb
+++ b/Databricks/ARCHIVE/BAIL/bails_to_eventhubs.ipynb
@@ -33,10 +33,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "d548262a-94eb-4b1e-8a38-9d5700f5fc5b",
      "showTitle": false,
@@ -134,7 +131,7 @@
    },
    "outputs": [],
    "source": [
-    "curated_storage_account = \"ingest00curatedsbox\"\n",
+    "curated_storage_account = f\"ingest{env}curatedsbox\"\n",
     "curated_container = \"gold\"\n",
     "silver_curated_container = \"silver\"\n",
     "\n"
@@ -225,10 +222,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "ca5d0732-52ee-47db-8fc2-e2cd9efaac84",
      "showTitle": false,
@@ -258,7 +252,7 @@
    },
    "outputs": [],
    "source": [
-    "eh_kv_secret = dbutils.secrets.get(scope=keyvault_name, key=\"EventHubNamespace-ConnStr\")"
+    "# eh_kv_secret = dbutils.secrets.get(scope=keyvault_name, key=\"EventHubNamespace-ConnStr\")"
    ]
   },
   {
@@ -374,10 +368,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "d99f4b22-2d4c-4550-9959-219d94d18973",
      "showTitle": false,

--- a/Databricks/ARCHIVE/BAIL/bails_to_eventhubs_A360.ipynb
+++ b/Databricks/ARCHIVE/BAIL/bails_to_eventhubs_A360.ipynb
@@ -131,8 +131,7 @@
    },
    "outputs": [],
    "source": [
-    "curated_storage_account = \"ingest00curatedsbox\"\n",
-    "\n",
+    "curated_storage_account = f\"ingest{env}curatedsbox\"\n",
     "gold_curated_container = \"gold\"\n",
     "silver_curated_container = \"silver\"\n"
    ]


### PR DESCRIPTION
Adding addtional f-strings to parameterise the correct storage account during pipeline runs eg searching for 02 when running in 02 vs 00.

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
