### PR TITLE
Updating the SBAILS DAB

### DIFF
--- a/ARIA_DABs/resources/pipelines/PL_ARIADM_ARM_SBAIL.yml
+++ b/ARIA_DABs/resources/pipelines/PL_ARIADM_ARM_SBAIL.yml
@@ -8,6 +8,7 @@ resources:
       clusters:
         - label: default
           node_type_id: Standard_D8ads_v5
+          driver_node_type_id: Standard_D4ads_v5
           autoscale:
             min_workers: 1
             max_workers: 8


### PR DESCRIPTION
specified in the SBAILS DAB to use driver node Standard_D4ads_v5