### PR TITLE
Fixing the audit paths for APPEALS FTA,UTA,FPA

### DIFF
--- a/Databricks/ARCHIVE/APPEALS/ARIAFPA/ARIADM_ACK_AUTOLOADER_FPA.ipynb
+++ b/Databricks/ARCHIVE/APPEALS/ARIAFPA/ARIADM_ACK_AUTOLOADER_FPA.ipynb
@@ -281,7 +281,7 @@
    "outputs": [],
    "source": [
     "# Container and path for storing Delta table (in curated storage account)\n",
-    "data_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFPA/fpa_ack_audit\"\n",
+    "data_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFPA/fpa_ack_audit_table\"\n",
     "\n",
     "# Container and path for checkpoint (in xcuttings storage account)\n",
     "checkpoint_path = f\"abfss://db-ack-checkpoint@ingest{lz_key}xcutting{env_name}.dfs.core.windows.net/APPEALS/ARIAFPA/ACK/ack\"\n"

--- a/Databricks/ARCHIVE/APPEALS/ARIAFPA/ARIA_ADLS_TO_EVENTHUBS_GENRIC_FPA.ipynb
+++ b/Databricks/ARCHIVE/APPEALS/ARIAFPA/ARIA_ADLS_TO_EVENTHUBS_GENRIC_FPA.ipynb
@@ -166,7 +166,7 @@
     "# topic = f\"evh-apl-{AppealCategory[-3:].lower()}-pub-dev-uks-dlrm-01\"\n",
     "topic = f\"evh-apl{AppealCategory[-3:].lower()}-pub-{lz_key}-uks-dlrm-01\"\n",
     "# dropzone_mount = f\"/mnt/dropzonearia{{AppealCategory[-3:].lower()}}/TD/\"\n",
-    "audit_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/{AppealCategory}/apl_{AppealCategory[-3:].lower()}_pub_audit_db_eh\"\n",
+    "audit_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/{AppealCategory}/apl_{AppealCategory[-3:].lower()}_pub_audit_table\"\n",
     "\n",
     "file_types = dbutils.widgets.get('file_types')\n",
     "\n",

--- a/Databricks/ARCHIVE/APPEALS/ARIAFPA/AUDIT/FPA_Send_Audit_Dashboard.ipynb
+++ b/Databricks/ARCHIVE/APPEALS/ARIAFPA/AUDIT/FPA_Send_Audit_Dashboard.ipynb
@@ -119,7 +119,7 @@
    },
    "outputs": [],
    "source": [
-    "df_fpa_ack_audit_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFPA/fpa_ack_audit/\")\n",
+    "df_fpa_ack_audit_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFPA/fpa_ack_audit_table/\")\n",
     "df_fpa_ack_audit_data.createOrReplaceTempView(\"fpa_acknowledge_audit_data\")"
    ]
   },
@@ -357,7 +357,7 @@
    },
    "outputs": [],
    "source": [
-    "df_fpa_pub_audit_db_eh = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFPA/apl_fpa_pub_audit_db_eh/\")\n",
+    "df_fpa_pub_audit_db_eh = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFPA/apl_fpa_pub_audit_table/\")\n",
     "df_fpa_pub_audit_db_eh.createOrReplaceTempView(\"fpa_pub_audit_db_eh\")"
    ]
   },
@@ -563,7 +563,7 @@
       "stack": true
      },
      "nuid": "3a28d7e3-185e-4471-854f-e70490451a21",
-     "origId": 5798811017172147,
+     "origId": 5608071033336300,
      "title": "ARIAFTA Send Audit Dashboard",
      "version": "DashboardViewV1",
      "width": 1024

--- a/Databricks/ARCHIVE/APPEALS/ARIAFTA/ARIADM_ACK_AUTOLOADER_FTA.ipynb
+++ b/Databricks/ARCHIVE/APPEALS/ARIAFTA/ARIADM_ACK_AUTOLOADER_FTA.ipynb
@@ -4,10 +4,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "ca145479-3655-4bf2-bafa-8c2894258a3b",
      "showTitle": false,
@@ -23,10 +20,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "81ef4be3-3c60-450c-91c7-9d09d193aea9",
      "showTitle": false,
@@ -287,7 +281,7 @@
    "outputs": [],
    "source": [
     "# Container and path for storing Delta table (in curated storage account)\n",
-    "data_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFTA/fta_ack_audit\"\n",
+    "data_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFTA/fta_ack_audit_table\"\n",
     "\n",
     "# Container and path for checkpoint (in xcuttings storage account)\n",
     "checkpoint_path = f\"abfss://db-ack-checkpoint@ingest{lz_key}xcutting{env_name}.dfs.core.windows.net/APPEALS/ARIAFTA/ACK/ack\"\n"

--- a/Databricks/ARCHIVE/APPEALS/ARIAFTA/ARIA_ADLS_TO_EVENTHUBS_GENRIC_FTA.ipynb
+++ b/Databricks/ARCHIVE/APPEALS/ARIAFTA/ARIA_ADLS_TO_EVENTHUBS_GENRIC_FTA.ipynb
@@ -166,7 +166,7 @@
     "# topic = f\"evh-apl-{AppealCategory[-3:].lower()}-pub-dev-uks-dlrm-01\"\n",
     "topic = f\"evh-apl{AppealCategory[-3:].lower()}-pub-{lz_key}-uks-dlrm-01\"\n",
     "# dropzone_mount = f\"/mnt/dropzonearia{{AppealCategory[-3:].lower()}}/TD/\"\n",
-    "audit_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/{AppealCategory}/apl_{AppealCategory[-3:].lower()}_pub_audit_db_eh\"\n",
+    "audit_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/{AppealCategory}/apl_{AppealCategory[-3:].lower()}_pub_audit_table\"\n",
     "\n",
     "file_types = dbutils.widgets.get('file_types')\n",
     "\n",

--- a/Databricks/ARCHIVE/APPEALS/ARIAFTA/AUDIT/FTA_Send_Audit_Dashboard.ipynb
+++ b/Databricks/ARCHIVE/APPEALS/ARIAFTA/AUDIT/FTA_Send_Audit_Dashboard.ipynb
@@ -119,7 +119,7 @@
    },
    "outputs": [],
    "source": [
-    "df_fta_ack_audit_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFTA/fta_ack_audit/\")\n",
+    "df_fta_ack_audit_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFTA/fta_ack_audit_table/\")\n",
     "df_fta_ack_audit_data.createOrReplaceTempView(\"fta_acknowledge_audit_data\")"
    ]
   },
@@ -213,6 +213,7 @@
        "iPythonMetadata": null,
        "inputWidgets": {},
        "isLockedInExamMode": false,
+       "latestAssumeRoleInfo": null,
        "latestUser": "a user",
        "latestUserId": null,
        "listResultMetadata": null,
@@ -356,7 +357,7 @@
    },
    "outputs": [],
    "source": [
-    "df_fta_pub_audit_db_eh = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFTA/apl_fta_pub_audit_db_eh/\")\n",
+    "df_fta_pub_audit_db_eh = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAFTA/apl_fta_pub_audit_table/\")\n",
     "df_fta_pub_audit_db_eh.createOrReplaceTempView(\"fta_pub_audit_db_eh\")"
    ]
   },
@@ -440,6 +441,7 @@
        "iPythonMetadata": null,
        "inputWidgets": {},
        "isLockedInExamMode": false,
+       "latestAssumeRoleInfo": null,
        "latestUser": "a user",
        "latestUserId": null,
        "listResultMetadata": null,
@@ -561,7 +563,7 @@
       "stack": true
      },
      "nuid": "3a28d7e3-185e-4471-854f-e70490451a21",
-     "origId": 6863293266399874,
+     "origId": 5608071033336395,
      "title": "ARIAFTA Send Audit Dashboard",
      "version": "DashboardViewV1",
      "width": 1024

--- a/Databricks/ARCHIVE/APPEALS/ARIAUTA/ARIADM_ACK_AUTOLOADER_UTA.ipynb
+++ b/Databricks/ARCHIVE/APPEALS/ARIAUTA/ARIADM_ACK_AUTOLOADER_UTA.ipynb
@@ -282,7 +282,7 @@
    "outputs": [],
    "source": [
     "# Container and path for storing Delta table (in curated storage account)\n",
-    "data_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAUTA/uta_ack_audit\"\n",
+    "data_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAUTA/uta_ack_audit_table\"\n",
     "\n",
     "# Container and path for checkpoint (in xcuttings storage account)\n",
     "checkpoint_path = f\"abfss://db-ack-checkpoint@ingest{lz_key}xcutting{env_name}.dfs.core.windows.net/APPEALS/ARIAUTA/ACK/ack\"\n"

--- a/Databricks/ARCHIVE/APPEALS/ARIAUTA/ARIA_ADLS_TO_EVENTHUBS_GENRIC_UTA.ipynb
+++ b/Databricks/ARCHIVE/APPEALS/ARIAUTA/ARIA_ADLS_TO_EVENTHUBS_GENRIC_UTA.ipynb
@@ -166,7 +166,7 @@
     "# topic = f\"evh-apl-{AppealCategory[-3:].lower()}-pub-dev-uks-dlrm-01\"\n",
     "topic = f\"evh-apl{AppealCategory[-3:].lower()}-pub-{lz_key}-uks-dlrm-01\"\n",
     "# dropzone_mount = f\"/mnt/dropzonearia{{AppealCategory[-3:].lower()}}/TD/\"\n",
-    "audit_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/{AppealCategory}/apl_{AppealCategory[-3:].lower()}_pub_audit_db_eh\"\n",
+    "audit_path = f\"abfss://silver@ingest{lz_key}curated{env_name}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/{AppealCategory}/apl_{AppealCategory[-3:].lower()}_pub_audit_table\"\n",
     "\n",
     "file_types = dbutils.widgets.get('file_types')\n",
     "\n",

--- a/Databricks/ARCHIVE/APPEALS/ARIAUTA/AUDIT/UTA_Send_Audit_Dashboard.ipynb
+++ b/Databricks/ARCHIVE/APPEALS/ARIAUTA/AUDIT/UTA_Send_Audit_Dashboard.ipynb
@@ -119,7 +119,7 @@
    },
    "outputs": [],
    "source": [
-    "df_uta_ack_audit_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAUTA/uta_ack_audit/\")\n",
+    "df_uta_ack_audit_data = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAUTA/uta_ack_audit_table/\")\n",
     "df_uta_ack_audit_data.createOrReplaceTempView(\"uta_acknowledge_audit_data\")"
    ]
   },
@@ -213,6 +213,7 @@
        "iPythonMetadata": null,
        "inputWidgets": {},
        "isLockedInExamMode": false,
+       "latestAssumeRoleInfo": null,
        "latestUser": "a user",
        "latestUserId": null,
        "listResultMetadata": null,
@@ -356,7 +357,7 @@
    },
    "outputs": [],
    "source": [
-    "df_uta_pub_audit_db_eh = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAUTA/apl_uta_pub_audit_db_eh/\")\n",
+    "df_uta_pub_audit_db_eh = spark.read.format(\"delta\").load(f\"abfss://{silver_container}@{curated_storage_account}.dfs.core.windows.net/ARIADM/ARM/AUDIT/APPEALS/ARIAUTA/apl_uta_pub_audit_table/\")\n",
     "df_uta_pub_audit_db_eh.createOrReplaceTempView(\"uta_pub_audit_db_eh\")"
    ]
   },
@@ -440,6 +441,7 @@
        "iPythonMetadata": null,
        "inputWidgets": {},
        "isLockedInExamMode": false,
+       "latestAssumeRoleInfo": null,
        "latestUser": "a user",
        "latestUserId": null,
        "listResultMetadata": null,
@@ -561,7 +563,7 @@
       "stack": true
      },
      "nuid": "3a28d7e3-185e-4471-854f-e70490451a21",
-     "origId": 6863293266399858,
+     "origId": 5608071033336492,
      "title": "UTA Send Audit Dashboard",
      "version": "DashboardViewV1",
      "width": 1024


### PR DESCRIPTION
ARIADM-868

Fixing the files paths for audit tables

all audit tables should me {segment}_{Action}_audit_table

Actions can be:
cr - creation
pub - publish
ack - acknowledgement

The file paths have also been updated in the Dashboard notebooks