### PR TITLE
Added additional condition to pull through CaseRep_Postcode if all ot…

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1086,13 +1086,18 @@ def legalRepDetails(silver_m1, bronze_countryFromAddress):
                         col("CaseRep_Address3").isNull() &
                         col("CaseRep_Address4").isNull() &
                         col("CaseRep_Address5").isNull(),
-                        col("CaseRep_Address2")   # override rule
+                        coalesce(
+                            col("CaseRep_Address2"),
+                            col("CaseRep_Postcode"),
+                            lit("")
+                        )
                     ).otherwise(
                         coalesce(
                             col("CaseRep_Address3"),
                             col("CaseRep_Address4"),
                             col("CaseRep_Address5"),
-                            lit(""),
+                            col("CaseRep_Postcode"),
+                            lit("")
                         )
                     ).alias("PostTown"),
 


### PR DESCRIPTION
…her fields are null to the PostTown field in legalRepAddressUK. The field is mandatory in CCD and was previously being ignored causing some DQ failures. All DQ now passing.

https://tools.hmcts.net/jira/browse/ARIADM-2053
