### PR TITLE
Apply padding to legalAidAccountNumber, update DQ to reflact changes

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
@@ -731,7 +731,7 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_legalAidAccountNumber_not_null"] = (
             """
                 (
-                    (dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA') AND remissionType <=> 'hoWaiverRemission' AND remissionClaim <=> 'legalAid' AND feeRemissionType <=> 'Legal Aid' AND legalAidAccountNumber IS NOT NULL)
+                    (dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA') AND remissionType <=> 'hoWaiverRemission' AND remissionClaim <=> 'legalAid' AND feeRemissionType <=> 'Legal Aid' AND legalAidAccountNumber IS NOT NULL AND length(legalAidAccountNumber) BETWEEN 6 AND 20)
                     OR
                     (dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA') AND (NOT(remissionType <=> 'hoWaiverRemission') OR NOT(remissionClaim <=> 'legalAid') OR NOT(feeRemissionType <=> 'Legal Aid')) AND legalAidAccountNumber IS NULL)
                     OR

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -15,7 +15,8 @@ from pyspark.sql.functions import (
     col, when, lit, array, struct, collect_list,
     max as spark_max, date_format, row_number, expr,
     size, udf, coalesce, concat_ws, concat, trim, year, split, datediff,
-    collect_set, current_timestamp, transform, first, array_contains, nullif, upper
+    collect_set, current_timestamp, transform, first, array_contains, nullif, upper,
+    lpad
 )
 from uk_postcodes_parsing import fix, postcode_utils
 
@@ -2527,10 +2528,12 @@ def remissionTypes(silver_m1, bronze_remission_lookup_df, silver_m4):
 
     ).withColumn(
         "legalAidAccountNumber",
+        lpad(
         when(col("legalAidAccountNumber") == lit("OMIT"), None                               #When set to OMIT, replace with NULL
         ).when(col("legalAidAccountNumber") == lit("M1.LSCReference; ELSE IF NULL 'Unknown'"),    #If record matches the string
         when(col("m1.LSCReference").isNotNull(), col("m1.LSCReference")).otherwise(lit("Unknown")) #Perform logic in the string
-    ).otherwise(col("legalAidAccountNumber"))
+    ).otherwise(col("legalAidAccountNumber")
+            ), 6, "0")
 
     ).withColumn(
         "asylumSupportReference",


### PR DESCRIPTION
CCD expects legalAidAccountNumber to be between 6 and 20 characters. PAdding was added per Bella's instructions (0) to the beginning of the value to ensure the length is always a minimum of six characters
