### PR TITLE
Remove duplicates flagged in 2214

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
@@ -556,8 +556,7 @@ def build_dq_rules_dependencies(df_final, silver_m1, silver_m2, silver_m3, silve
             .join(detained_df, on="CaseNo", how="left")
             .join(cs46_out31, on="CaseNo", how="left")
             .join(silver_m3_max_casestatus_no_filter, on="CaseNo", how="left")
-
-    )
+    ).dropDuplicates(["CaseNo"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ARIADM-2214

Tested fix on five states highlighted in 2214. Each pipeline now produces the expected counts between pipeline and storage account, including matching segmentation

listing: 834 + 38 = 872                 ✅
PFH:  2213 + 95 = 2308               ✅
decided_a = 2143 + 73 = 2216    ✅
ftpaSubmittedB: 227 + 12 = 239 ✅
ended: 711 + 2 = 713                     ✅
