### PR TITLE
Fix ordering, produce correct outputs

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1948,7 +1948,7 @@ def cleanReferenceNumber(ref):
     """
 
     if ref is None or ref == '' or ref.strip().upper() == 'NULL':
-        return '999999999'
+        return None
 
     if len(ref) > 9 and len(ref) < 16:
         no_letters = re.sub(r"[a-zA-Z]", "", ref)
@@ -2077,7 +2077,7 @@ def homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing):
             cleanReferenceNumberUDF(col("HORef")),
             cleanReferenceNumberUDF(col("FCONumber"))
         )
-    ).otherwise(lit(None))
+    ).otherwise(lit("999999999"))
 
     # IF CategoryId IN [38] AND  IF CleansedHORef OR M1.HORef OR M2.FCONumber LIKE '%GWF%' = Include; ELSE OMIT
     # IF CleansedHORef IS NULL USE HORef; IF HORef IS NULL USE FCONumber

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1943,6 +1943,9 @@ def cleanReferenceNumber(ref):
     8. Handling no reference number e.g., null or '' -> "999999999"
     """
 
+    if ref and re.fullmatch(r"X{2,32}", ref.strip().upper()):
+        return None
+
     if ref is None or ref == '' or ref.strip().upper() == 'NULL':
         return None
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1947,6 +1947,9 @@ def cleanReferenceNumber(ref):
     8. Handling no reference number e.g., null or '' -> "999999999"
     """
 
+    if ref and re.fullmatch(r"X{2,32}", ref.strip().upper()):
+        return None
+
     if ref is None or ref == '' or ref.strip().upper() == 'NULL':
         return None
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1944,7 +1944,7 @@ def cleanReferenceNumber(ref):
     """
 
     if ref is None or ref == '' or ref.strip().upper() == 'NULL':
-        return '999999999'
+        return None
 
     if len(ref) > 9 and len(ref) < 16:
         no_letters = re.sub(r"[a-zA-Z]", "", ref)
@@ -2073,7 +2073,7 @@ def homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing):
             cleanReferenceNumberUDF(col("HORef")),
             cleanReferenceNumberUDF(col("FCONumber"))
         )
-    ).otherwise(lit(None))
+    ).otherwise(lit("999999999"))
 
     # IF CategoryId IN [38] AND  IF CleansedHORef OR M1.HORef OR M2.FCONumber LIKE '%GWF%' = Include; ELSE OMIT
     # IF CleansedHORef IS NULL USE HORef; IF HORef IS NULL USE FCONumber


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ARIADM-1874

Update the ordering of when to introduce "99999999". The current set-up sets null to 999999999 instantly, which prevent coalesce logic working during UDF.

The new approach sets the value to None first. The coalesce logic can then pick from HORef / lu_HORef if either are null. If the value automatically sets to 99999999 then the coalesce behaviour automatically returns the value instead of moving to the next column, which could contain the correct value.

The .otherwise() is the final catch to say "if no values exist, set to '99999999'" which is the expected behaviour and the results are now in-line with what we expect to see
