### PR TITLE
fix-CDAMDashboard-UserFriendly

### DIFF
--- a/Databricks/ACTIVE/MVP/CDAM/CDAM_Tracking_Dashboard.ipynb
+++ b/Databricks/ACTIVE/MVP/CDAM/CDAM_Tracking_Dashboard.ipynb
@@ -9,12 +9,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1777467295002,
+     "finishTime": 1779361715595,
      "inputWidgets": {},
      "nuid": "f4609d39-8e6c-41d5-9abf-392a9ee56455",
      "showTitle": true,
-     "startTime": 1777467294928,
-     "submitTime": 1777467294730,
+     "startTime": 1779361715518,
+     "submitTime": 1779361711485,
      "tableResultSettingsMap": {},
      "title": "Import Libraries"
     }
@@ -33,12 +33,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1777467295204,
+     "finishTime": 1779361715793,
      "inputWidgets": {},
      "nuid": "64cf17e7-1a72-4e5d-b50f-835f5f169017",
      "showTitle": true,
-     "startTime": 1777467295024,
-     "submitTime": 1777467294735,
+     "startTime": 1779361715618,
+     "submitTime": 1779361711493,
      "tableResultSettingsMap": {},
      "title": "Initialise logging"
     }
@@ -63,12 +63,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1777467295703,
+     "finishTime": 1779361716294,
      "inputWidgets": {},
      "nuid": "3010f725-1597-452d-89a1-d3636edff2ad",
      "showTitle": true,
-     "startTime": 1777467295216,
-     "submitTime": 1777467294739,
+     "startTime": 1779361715799,
+     "submitTime": 1779361711499,
      "tableResultSettingsMap": {},
      "title": "Set-up cnfigs"
     }
@@ -109,12 +109,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1777467296304,
+     "finishTime": 1779361716795,
      "inputWidgets": {},
      "nuid": "daf71926-d55f-4e3c-be2a-8ae9808b5390",
      "showTitle": true,
-     "startTime": 1777467295717,
-     "submitTime": 1777467294743,
+     "startTime": 1779361716307,
+     "submitTime": 1779361711504,
      "tableResultSettingsMap": {},
      "title": "Set-up OAuth"
     }
@@ -155,12 +155,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1777467296504,
+     "finishTime": 1779361716895,
      "inputWidgets": {},
      "nuid": "881b1297-abd6-47b9-83f3-0111b4a47cd8",
      "showTitle": true,
-     "startTime": 1777467296313,
-     "submitTime": 1777467294746,
+     "startTime": 1779361716803,
+     "submitTime": 1779361711510,
      "tableResultSettingsMap": {},
      "title": "Assign OAuth"
     }
@@ -210,12 +210,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1777467553298,
+     "finishTime": 1779361722105,
      "inputWidgets": {},
      "nuid": "86c6ca78-8d30-4ebc-a762-4adb3a11fdc6",
      "showTitle": true,
-     "startTime": 1777467551773,
-     "submitTime": 1777467551708,
+     "startTime": 1779361716901,
+     "submitTime": 1779361711515,
      "tableResultSettingsMap": {
       "0": {
        "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1764156534467}",
@@ -240,7 +240,7 @@
        "baseErrorDetails": null,
        "bindings": {},
        "collapsed": false,
-       "command": "%python\n__backend_agg_display_orig = display\n__backend_agg_dfs = []\ndef __backend_agg_display_new(df):\n    __backend_agg_df_modules = [\"pandas.core.frame\", \"databricks.koalas.frame\", \"pyspark.sql.dataframe\", \"pyspark.pandas.frame\", \"pyspark.sql.connect.dataframe\", \"pyspark.sql.classic.dataframe\"]\n    if (type(df).__module__ in __backend_agg_df_modules and type(df).__name__ == 'DataFrame') or isinstance(df, list):\n        __backend_agg_dfs.append(df)\n\ndisplay = __backend_agg_display_new\n\ndef __backend_agg_user_code_fn():\n    import base64\n    exec(base64.standard_b64decode(\"Y2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0ID0gc3BhcmsucmVhZC5mb3JtYXQoImRlbHRhIikubG9hZChmImFiZnNzOi8ve3NpbHZlcl9jdXJhdGVkX2NvbnRhaW5lcn1Ae2N1cmF0ZWRfc3RvcmFnZV9hY2NvdW50fS5kZnMuY29yZS53aW5kb3dzLm5ldC9BUklBRE0vQUNUSVZFL0NDRC9BUFBFQUxTL0NEQU0vcHVibGlzaF9wYXlsb2FkX2F1ZGl0IikKY2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0LmNyZWF0ZU9yUmVwbGFjZVRlbXBWaWV3KCJjZGFtX3B1Ymxpc2hfcGF5bG9hZF9yZXN1bHQiKQoKY2RhbV9jYWxsX3Jlc3VsdCA9IHNwYXJrLnJlYWQuZm9ybWF0KCJkZWx0YSIpLmxvYWQoZiJhYmZzczovL3tzaWx2ZXJfY3VyYXRlZF9jb250YWluZXJ9QHtjdXJhdGVkX3N0b3JhZ2VfYWNjb3VudH0uZGZzLmNvcmUud2luZG93cy5uZXQvQVJJQURNL0FDVElWRS9DQ0QvQVVESVQvQVBQRUFMUy9DREFNL2Fja19hdWRpdCIpCmNkYW1fY2FsbF9yZXN1bHQuY3JlYXRlT3JSZXBsYWNlVGVtcFZpZXcoImNkYW1fY2FsbF9yZXN1bHQiKQoKZGlzcGxheShzcGFyay5zcWwoIiIiCiAgICBTRUxFQ1QgCiAgICAgICAgQ09BTEVTQ0UodDIuUnVuSWQsIHQxLlJ1bklkKSBBUyBSdW5JRCwKICAgICAgICBDT0FMRVNDRSh0Mi5DYXNlTm8sIHQxLkNhc2VObykgYXMgYENhc2VOb2AsCiAgICAgICAgdDEuU3RhdHVzIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgVVJMIFB1Ymxpc2ggU3RhdHVzYCwKICAgICAgICB0Mi5TdGF0dXMgYXMgYENEQU0gQ2FsbCBTdGF0dXNgLAogICAgICAgIHQxLkZpbGVOYW1lIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgRmlsZSBOYW1lYCwKICAgICAgICB0MS5GaWxlVVJMIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgRmlsZSBVUkxgLAogICAgICAgIHQxLlB1Ymxpc2hpbmdEYXRlVGltZSBhcyBgQ2FzZSBOb3RlIERvY3VtZW50IFB1Ymxpc2ggUHVibGlzaGluZyBEYXRlIFRpbWVgLAogICAgICAgIHQxLkVycm9yIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgUHVibGlzaCBFcnJvcmAsCiAgICAgICAgdDIuU3RhcnREYXRlVGltZSBhcyBgQ0RBTSBDYWxsIEZ1bmN0aW9uIEFwcCBTdGFydCBEYXRlIFRpbWVgLAogICAgICAgIHQyLkVuZERhdGVUaW1lIGFzIGBDREFNIENhbGwgRnVuY3Rpb24gQXBwIEVuZCBEYXRlIFRpbWVgLAogICAgICAgIHQyLkVycm9yIGFzIGBDREFNIENhbGwgRnVuY3Rpb24gQXBwIEVycm9yYCwKICAgICAgICB0Mi5kb2N1bWVudF9maWxlbmFtZSBhcyBgQ0RBTSBkb2N1bWVudF9maWxlbmFtZWAsCiAgICAgICAgdDIuZG9jdW1lbnRfdXJsIGFzIGBDREFNIGRvY3VtZW50X3VybGAsCiAgICAgICAgdDIuY3JlYXRlZE9uIGFzIGBDREFNIGNyZWF0ZWRPbmAKICAgIEZST00gY2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0IHQxCiAgICAgICAgRlVMTCBPVVRFUiBKT0lOIGNkYW1fY2FsbF9yZXN1bHQgdDIgT04gdDEuQ2FzZU5vID0gdDIuQ2FzZU5vIEFORCB0MS5SdW5JRCA9IHQyLlJ1bklECiAgICBPUkRFUiBCWSBgQ2FzZSBOb3RlIERvY3VtZW50IFB1Ymxpc2ggUHVibGlzaGluZyBEYXRlIFRpbWVgIERFU0MKIiIiKSk=\").decode())\n\ntry:\n    # run user code\n    __backend_agg_user_code_fn()\n\n    #reset display function\n    display = __backend_agg_display_orig\n\n    if len(__backend_agg_dfs) > 0:\n        # create a temp view\n        if type(__backend_agg_dfs[0]).__module__ == \"databricks.koalas.frame\":\n            # koalas dataframe\n            __backend_agg_dfs[0].to_spark().createOrReplaceTempView(\"DatabricksViewc060d02\")\n        elif type(__backend_agg_dfs[0]).__module__ == \"pandas.core.frame\" or isinstance(__backend_agg_dfs[0], list):\n            # pandas dataframe\n            spark.createDataFrame(__backend_agg_dfs[0]).createOrReplaceTempView(\"DatabricksViewc060d02\")\n        else:\n            __backend_agg_dfs[0].createOrReplaceTempView(\"DatabricksViewc060d02\")\n        #run backend agg\n        display(spark.sql(\"\"\"WITH q AS (select * from DatabricksViewc060d02) SELECT `RunID`,COUNT(`Case Note Document URL Publish Status`) `column_1d11d9df465`,`Case Note Document URL Publish Status` FROM q GROUP BY `Case Note Document URL Publish Status`,`RunID`\"\"\"))\n    else:\n        displayHTML(\"dataframe no longer exists. If you're using dataframe.display(), use display(dataframe) instead.\")\n\n\nfinally:\n    spark.sql(\"drop view if exists DatabricksViewc060d02\")\n    display = __backend_agg_display_orig\n    del __backend_agg_display_new\n    del __backend_agg_display_orig\n    del __backend_agg_dfs\n    del __backend_agg_user_code_fn\n\n",
+       "command": "%python\n__backend_agg_display_orig = display\n__backend_agg_dfs = []\ndef __backend_agg_display_new(df):\n    __backend_agg_df_modules = [\"pandas.core.frame\", \"databricks.koalas.frame\", \"pyspark.sql.dataframe\", \"pyspark.pandas.frame\", \"pyspark.sql.connect.dataframe\", \"pyspark.sql.classic.dataframe\"]\n    if (type(df).__module__ in __backend_agg_df_modules and type(df).__name__ == 'DataFrame') or isinstance(df, list):\n        __backend_agg_dfs.append(df)\n\ndisplay = __backend_agg_display_new\n\ndef __backend_agg_user_code_fn():\n    import base64\n    exec(base64.standard_b64decode(\"Y2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0ID0gc3BhcmsucmVhZC5mb3JtYXQoImRlbHRhIikubG9hZChmImFiZnNzOi8ve3NpbHZlcl9jdXJhdGVkX2NvbnRhaW5lcn1Ae2N1cmF0ZWRfc3RvcmFnZV9hY2NvdW50fS5kZnMuY29yZS53aW5kb3dzLm5ldC9BUklBRE0vQUNUSVZFL0NDRC9BUFBFQUxTL0NEQU0vcHVibGlzaF9wYXlsb2FkX2F1ZGl0IikKY2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0LmNyZWF0ZU9yUmVwbGFjZVRlbXBWaWV3KCJjZGFtX3B1Ymxpc2hfcGF5bG9hZF9yZXN1bHQiKQoKY2RhbV9jYWxsX3Jlc3VsdCA9IHNwYXJrLnJlYWQuZm9ybWF0KCJkZWx0YSIpLmxvYWQoZiJhYmZzczovL3tzaWx2ZXJfY3VyYXRlZF9jb250YWluZXJ9QHtjdXJhdGVkX3N0b3JhZ2VfYWNjb3VudH0uZGZzLmNvcmUud2luZG93cy5uZXQvQVJJQURNL0FDVElWRS9DQ0QvQVVESVQvQVBQRUFMUy9DREFNL2Fja19hdWRpdCIpCmNkYW1fY2FsbF9yZXN1bHQuY3JlYXRlT3JSZXBsYWNlVGVtcFZpZXcoImNkYW1fY2FsbF9yZXN1bHQiKQoKZGlzcGxheShzcGFyay5zcWwoIiIiCiAgICBTRUxFQ1QgCiAgICAgICAgQ09BTEVTQ0UodDIuUnVuSWQsIHQxLlJ1bklkKSBBUyBSdW5JRCwKICAgICAgICBDT0FMRVNDRSh0Mi5DYXNlTm8sIHQxLkNhc2VObykgYXMgYENhc2VOb2AsCiAgICAgICAgdDEuU3RhdHVzIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgVVJMIFB1Ymxpc2ggU3RhdHVzYCwKICAgICAgICB0Mi5TdGF0dXMgYXMgYENEQU0gQ2FsbCBTdGF0dXNgLAogICAgICAgIHQxLkZpbGVOYW1lIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgRmlsZSBOYW1lYCwKICAgICAgICB0MS5GaWxlVVJMIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgRmlsZSBVUkxgLAogICAgICAgIHQxLlB1Ymxpc2hpbmdEYXRlVGltZSBhcyBgQ2FzZSBOb3RlIERvY3VtZW50IFB1Ymxpc2ggUHVibGlzaGluZyBEYXRlIFRpbWVgLAogICAgICAgIHQxLkVycm9yIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgUHVibGlzaCBFcnJvcmAsCiAgICAgICAgdDIuU3RhcnREYXRlVGltZSBhcyBgQ0RBTSBDYWxsIEZ1bmN0aW9uIEFwcCBTdGFydCBEYXRlIFRpbWVgLAogICAgICAgIHQyLkVuZERhdGVUaW1lIGFzIGBDREFNIENhbGwgRnVuY3Rpb24gQXBwIEVuZCBEYXRlIFRpbWVgLAogICAgICAgIHQyLkVycm9yIGFzIGBDREFNIENhbGwgRnVuY3Rpb24gQXBwIEVycm9yYCwKICAgICAgICB0Mi5kb2N1bWVudF9maWxlbmFtZSBhcyBgQ0RBTSBkb2N1bWVudF9maWxlbmFtZWAsCiAgICAgICAgdDIuZG9jdW1lbnRfdXJsIGFzIGBDREFNIGRvY3VtZW50X3VybGAsCiAgICAgICAgdDIuY3JlYXRlZE9uIGFzIGBDREFNIGNyZWF0ZWRPbmAKICAgIEZST00gY2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0IHQxCiAgICAgICAgRlVMTCBPVVRFUiBKT0lOIGNkYW1fY2FsbF9yZXN1bHQgdDIgT04gdDEuQ2FzZU5vID0gdDIuQ2FzZU5vIEFORCB0MS5SdW5JRCA9IHQyLlJ1bklECiAgICBPUkRFUiBCWSBgQ2FzZSBOb3RlIERvY3VtZW50IFB1Ymxpc2ggUHVibGlzaGluZyBEYXRlIFRpbWVgIERFU0MKIiIiKSk=\").decode())\n\ntry:\n    # run user code\n    __backend_agg_user_code_fn()\n\n    #reset display function\n    display = __backend_agg_display_orig\n\n    if len(__backend_agg_dfs) > 0:\n        # create a temp view\n        if type(__backend_agg_dfs[0]).__module__ == \"databricks.koalas.frame\":\n            # koalas dataframe\n            __backend_agg_dfs[0].to_spark().createOrReplaceTempView(\"DatabricksView2495c31\")\n        elif type(__backend_agg_dfs[0]).__module__ == \"pandas.core.frame\" or isinstance(__backend_agg_dfs[0], list):\n            # pandas dataframe\n            spark.createDataFrame(__backend_agg_dfs[0]).createOrReplaceTempView(\"DatabricksView2495c31\")\n        else:\n            __backend_agg_dfs[0].createOrReplaceTempView(\"DatabricksView2495c31\")\n        #run backend agg\n        display(spark.sql(\"\"\"WITH q AS (select * from DatabricksView2495c31) SELECT `Case Note Document URL Publish Status`,`RunID`,COUNT(`Case Note Document URL Publish Status`) `column_1d11d9df465`,COUNT(`CDAM Call Status`) `column_24a7d97c160` FROM q GROUP BY `Case Note Document URL Publish Status`,`RunID`\"\"\"))\n    else:\n        displayHTML(\"dataframe no longer exists. If you're using dataframe.display(), use display(dataframe) instead.\")\n\n\nfinally:\n    spark.sql(\"drop view if exists DatabricksView2495c31\")\n    display = __backend_agg_display_orig\n    del __backend_agg_display_new\n    del __backend_agg_display_orig\n    del __backend_agg_dfs\n    del __backend_agg_user_code_fn\n\n",
        "commandTitle": "Visualization Publish",
        "commandType": "auto",
        "commandVersion": 0,
@@ -272,6 +272,11 @@
               "column": "Case Note Document URL Publish Status",
               "id": "column_1d11d9df465",
               "transform": "COUNT"
+             },
+             {
+              "column": "CDAM Call Status",
+              "id": "column_24a7d97c160",
+              "transform": "COUNT"
              }
             ]
            },
@@ -286,6 +291,8 @@
            "globalSeriesType": "column",
            "isAggregationOn": true,
            "legend": {
+            "enabled": true,
+            "placement": "below",
             "traceorder": "normal"
            },
            "missingValuesAsZero": true,
@@ -299,12 +306,24 @@
             "stacking": null
            },
            "seriesOptions": {
+            "SUCCESS, COUNT(CDAM Call Status)": {
+             "color": "#00A972",
+             "name": "Count of Response (Success)"
+            },
+            "SUCCESS, COUNT(Case Note Document URL Publish Status)": {
+             "color": "#00A972",
+             "name": "Count of Publish (Success)"
+            },
             "column_1d11d9df465": {
+             "type": "column",
+             "yAxis": 0
+            },
+            "column_24a7d97c160": {
              "type": "column",
              "yAxis": 0
             }
            },
-           "showDataLabels": false,
+           "showDataLabels": true,
            "sizemode": "diameter",
            "sortX": true,
            "sortY": true,
@@ -315,12 +334,15 @@
            "version": 2,
            "xAxis": {
             "labels": {
-             "enabled": true
+             "enabled": false
             },
             "type": "-"
            },
            "yAxis": [
             {
+             "title": {
+              "text": "Count of Records"
+             },
              "type": "-"
             },
             {
@@ -340,7 +362,7 @@
        "errorDetails": null,
        "errorSummary": null,
        "errorTraceType": null,
-       "finishTime": 1777467567111,
+       "finishTime": 1779361888125,
        "globalVars": {},
        "guid": "",
        "height": "auto",
@@ -372,22 +394,26 @@
        "resultDbfsStatus": "INLINED_IN_TREE",
        "results": null,
        "showCommandTitle": true,
-       "startTime": 1777467565325,
+       "startTime": 1779361885707,
        "state": "input",
        "streamStates": {},
        "subcommandOptions": {
         "queryPlan": {
          "groups": [
           {
-           "column": "RunID",
+           "column": "Case Note Document URL Publish Status",
            "type": "column"
           },
           {
-           "column": "Case Note Document URL Publish Status",
+           "column": "RunID",
            "type": "column"
           }
          ],
          "selects": [
+          {
+           "column": "Case Note Document URL Publish Status",
+           "type": "column"
+          },
           {
            "column": "RunID",
            "type": "column"
@@ -404,13 +430,20 @@
            "type": "function"
           },
           {
-           "column": "Case Note Document URL Publish Status",
-           "type": "column"
+           "alias": "column_24a7d97c160",
+           "args": [
+            {
+             "column": "CDAM Call Status",
+             "type": "column"
+            }
+           ],
+           "function": "COUNT",
+           "type": "function"
           }
          ]
         }
        },
-       "submitTime": 1777467565269,
+       "submitTime": 1779361885598,
        "subtype": "tableResultSubCmd.visualization",
        "tableResultIndex": 0,
        "tableResultSettingsMap": {},
@@ -436,7 +469,7 @@
        "baseErrorDetails": null,
        "bindings": {},
        "collapsed": false,
-       "command": "%python\n__backend_agg_display_orig = display\n__backend_agg_dfs = []\ndef __backend_agg_display_new(df):\n    __backend_agg_df_modules = [\"pandas.core.frame\", \"databricks.koalas.frame\", \"pyspark.sql.dataframe\", \"pyspark.pandas.frame\", \"pyspark.sql.connect.dataframe\", \"pyspark.sql.classic.dataframe\"]\n    if (type(df).__module__ in __backend_agg_df_modules and type(df).__name__ == 'DataFrame') or isinstance(df, list):\n        __backend_agg_dfs.append(df)\n\ndisplay = __backend_agg_display_new\n\ndef __backend_agg_user_code_fn():\n    import base64\n    exec(base64.standard_b64decode(\"Y2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0ID0gc3BhcmsucmVhZC5mb3JtYXQoImRlbHRhIikubG9hZChmImFiZnNzOi8ve3NpbHZlcl9jdXJhdGVkX2NvbnRhaW5lcn1Ae2N1cmF0ZWRfc3RvcmFnZV9hY2NvdW50fS5kZnMuY29yZS53aW5kb3dzLm5ldC9BUklBRE0vQUNUSVZFL0NDRC9BUFBFQUxTL0NEQU0vcHVibGlzaF9wYXlsb2FkX2F1ZGl0IikKY2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0LmNyZWF0ZU9yUmVwbGFjZVRlbXBWaWV3KCJjZGFtX3B1Ymxpc2hfcGF5bG9hZF9yZXN1bHQiKQoKY2RhbV9jYWxsX3Jlc3VsdCA9IHNwYXJrLnJlYWQuZm9ybWF0KCJkZWx0YSIpLmxvYWQoZiJhYmZzczovL3tzaWx2ZXJfY3VyYXRlZF9jb250YWluZXJ9QHtjdXJhdGVkX3N0b3JhZ2VfYWNjb3VudH0uZGZzLmNvcmUud2luZG93cy5uZXQvQVJJQURNL0FDVElWRS9DQ0QvQVVESVQvQVBQRUFMUy9DREFNL2Fja19hdWRpdCIpCmNkYW1fY2FsbF9yZXN1bHQuY3JlYXRlT3JSZXBsYWNlVGVtcFZpZXcoImNkYW1fY2FsbF9yZXN1bHQiKQoKZGlzcGxheShzcGFyay5zcWwoIiIiCiAgICBTRUxFQ1QgCiAgICAgICAgQ09BTEVTQ0UodDIuUnVuSWQsIHQxLlJ1bklkKSBBUyBSdW5JRCwKICAgICAgICBDT0FMRVNDRSh0Mi5DYXNlTm8sIHQxLkNhc2VObykgYXMgYENhc2VOb2AsCiAgICAgICAgdDEuU3RhdHVzIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgVVJMIFB1Ymxpc2ggU3RhdHVzYCwKICAgICAgICB0Mi5TdGF0dXMgYXMgYENEQU0gQ2FsbCBTdGF0dXNgLAogICAgICAgIHQxLkZpbGVOYW1lIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgRmlsZSBOYW1lYCwKICAgICAgICB0MS5GaWxlVVJMIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgRmlsZSBVUkxgLAogICAgICAgIHQxLlB1Ymxpc2hpbmdEYXRlVGltZSBhcyBgQ2FzZSBOb3RlIERvY3VtZW50IFB1Ymxpc2ggUHVibGlzaGluZyBEYXRlIFRpbWVgLAogICAgICAgIHQxLkVycm9yIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgUHVibGlzaCBFcnJvcmAsCiAgICAgICAgdDIuU3RhcnREYXRlVGltZSBhcyBgQ0RBTSBDYWxsIEZ1bmN0aW9uIEFwcCBTdGFydCBEYXRlIFRpbWVgLAogICAgICAgIHQyLkVuZERhdGVUaW1lIGFzIGBDREFNIENhbGwgRnVuY3Rpb24gQXBwIEVuZCBEYXRlIFRpbWVgLAogICAgICAgIHQyLkVycm9yIGFzIGBDREFNIENhbGwgRnVuY3Rpb24gQXBwIEVycm9yYCwKICAgICAgICB0Mi5kb2N1bWVudF9maWxlbmFtZSBhcyBgQ0RBTSBkb2N1bWVudF9maWxlbmFtZWAsCiAgICAgICAgdDIuZG9jdW1lbnRfdXJsIGFzIGBDREFNIGRvY3VtZW50X3VybGAsCiAgICAgICAgdDIuY3JlYXRlZE9uIGFzIGBDREFNIGNyZWF0ZWRPbmAKICAgIEZST00gY2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0IHQxCiAgICAgICAgRlVMTCBPVVRFUiBKT0lOIGNkYW1fY2FsbF9yZXN1bHQgdDIgT04gdDEuQ2FzZU5vID0gdDIuQ2FzZU5vIEFORCB0MS5SdW5JRCA9IHQyLlJ1bklECiAgICBPUkRFUiBCWSBgQ2FzZSBOb3RlIERvY3VtZW50IFB1Ymxpc2ggUHVibGlzaGluZyBEYXRlIFRpbWVgIERFU0MKIiIiKSk=\").decode())\n\ntry:\n    # run user code\n    __backend_agg_user_code_fn()\n\n    #reset display function\n    display = __backend_agg_display_orig\n\n    if len(__backend_agg_dfs) > 0:\n        # create a temp view\n        if type(__backend_agg_dfs[0]).__module__ == \"databricks.koalas.frame\":\n            # koalas dataframe\n            __backend_agg_dfs[0].to_spark().createOrReplaceTempView(\"DatabricksView7ca894b\")\n        elif type(__backend_agg_dfs[0]).__module__ == \"pandas.core.frame\" or isinstance(__backend_agg_dfs[0], list):\n            # pandas dataframe\n            spark.createDataFrame(__backend_agg_dfs[0]).createOrReplaceTempView(\"DatabricksView7ca894b\")\n        else:\n            __backend_agg_dfs[0].createOrReplaceTempView(\"DatabricksView7ca894b\")\n        #run backend agg\n        display(spark.sql(\"\"\"WITH q AS (select * from DatabricksView7ca894b) SELECT `RunID`,COUNT(`CDAM Call Status`) `column_1d11d9df473`,`CDAM Call Status` FROM q GROUP BY `CDAM Call Status`,`RunID`\"\"\"))\n    else:\n        displayHTML(\"dataframe no longer exists. If you're using dataframe.display(), use display(dataframe) instead.\")\n\n\nfinally:\n    spark.sql(\"drop view if exists DatabricksView7ca894b\")\n    display = __backend_agg_display_orig\n    del __backend_agg_display_new\n    del __backend_agg_display_orig\n    del __backend_agg_dfs\n    del __backend_agg_user_code_fn\n\n",
+       "command": "%python\n__backend_agg_display_orig = display\n__backend_agg_dfs = []\ndef __backend_agg_display_new(df):\n    __backend_agg_df_modules = [\"pandas.core.frame\", \"databricks.koalas.frame\", \"pyspark.sql.dataframe\", \"pyspark.pandas.frame\", \"pyspark.sql.connect.dataframe\", \"pyspark.sql.classic.dataframe\"]\n    if (type(df).__module__ in __backend_agg_df_modules and type(df).__name__ == 'DataFrame') or isinstance(df, list):\n        __backend_agg_dfs.append(df)\n\ndisplay = __backend_agg_display_new\n\ndef __backend_agg_user_code_fn():\n    import base64\n    exec(base64.standard_b64decode(\"Y2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0ID0gc3BhcmsucmVhZC5mb3JtYXQoImRlbHRhIikubG9hZChmImFiZnNzOi8ve3NpbHZlcl9jdXJhdGVkX2NvbnRhaW5lcn1Ae2N1cmF0ZWRfc3RvcmFnZV9hY2NvdW50fS5kZnMuY29yZS53aW5kb3dzLm5ldC9BUklBRE0vQUNUSVZFL0NDRC9BUFBFQUxTL0NEQU0vcHVibGlzaF9wYXlsb2FkX2F1ZGl0IikKY2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0LmNyZWF0ZU9yUmVwbGFjZVRlbXBWaWV3KCJjZGFtX3B1Ymxpc2hfcGF5bG9hZF9yZXN1bHQiKQoKY2RhbV9jYWxsX3Jlc3VsdCA9IHNwYXJrLnJlYWQuZm9ybWF0KCJkZWx0YSIpLmxvYWQoZiJhYmZzczovL3tzaWx2ZXJfY3VyYXRlZF9jb250YWluZXJ9QHtjdXJhdGVkX3N0b3JhZ2VfYWNjb3VudH0uZGZzLmNvcmUud2luZG93cy5uZXQvQVJJQURNL0FDVElWRS9DQ0QvQVVESVQvQVBQRUFMUy9DREFNL2Fja19hdWRpdCIpCmNkYW1fY2FsbF9yZXN1bHQuY3JlYXRlT3JSZXBsYWNlVGVtcFZpZXcoImNkYW1fY2FsbF9yZXN1bHQiKQoKZGlzcGxheShzcGFyay5zcWwoIiIiCiAgICBTRUxFQ1QgCiAgICAgICAgQ09BTEVTQ0UodDIuUnVuSWQsIHQxLlJ1bklkKSBBUyBSdW5JRCwKICAgICAgICBDT0FMRVNDRSh0Mi5DYXNlTm8sIHQxLkNhc2VObykgYXMgYENhc2VOb2AsCiAgICAgICAgdDEuU3RhdHVzIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgVVJMIFB1Ymxpc2ggU3RhdHVzYCwKICAgICAgICB0Mi5TdGF0dXMgYXMgYENEQU0gQ2FsbCBTdGF0dXNgLAogICAgICAgIHQxLkZpbGVOYW1lIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgRmlsZSBOYW1lYCwKICAgICAgICB0MS5GaWxlVVJMIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgRmlsZSBVUkxgLAogICAgICAgIHQxLlB1Ymxpc2hpbmdEYXRlVGltZSBhcyBgQ2FzZSBOb3RlIERvY3VtZW50IFB1Ymxpc2ggUHVibGlzaGluZyBEYXRlIFRpbWVgLAogICAgICAgIHQxLkVycm9yIGFzIGBDYXNlIE5vdGUgRG9jdW1lbnQgUHVibGlzaCBFcnJvcmAsCiAgICAgICAgdDIuU3RhcnREYXRlVGltZSBhcyBgQ0RBTSBDYWxsIEZ1bmN0aW9uIEFwcCBTdGFydCBEYXRlIFRpbWVgLAogICAgICAgIHQyLkVuZERhdGVUaW1lIGFzIGBDREFNIENhbGwgRnVuY3Rpb24gQXBwIEVuZCBEYXRlIFRpbWVgLAogICAgICAgIHQyLkVycm9yIGFzIGBDREFNIENhbGwgRnVuY3Rpb24gQXBwIEVycm9yYCwKICAgICAgICB0Mi5kb2N1bWVudF9maWxlbmFtZSBhcyBgQ0RBTSBkb2N1bWVudF9maWxlbmFtZWAsCiAgICAgICAgdDIuZG9jdW1lbnRfdXJsIGFzIGBDREFNIGRvY3VtZW50X3VybGAsCiAgICAgICAgdDIuY3JlYXRlZE9uIGFzIGBDREFNIGNyZWF0ZWRPbmAKICAgIEZST00gY2RhbV9wdWJsaXNoX3BheWxvYWRfcmVzdWx0IHQxCiAgICAgICAgRlVMTCBPVVRFUiBKT0lOIGNkYW1fY2FsbF9yZXN1bHQgdDIgT04gdDEuQ2FzZU5vID0gdDIuQ2FzZU5vIEFORCB0MS5SdW5JRCA9IHQyLlJ1bklECiAgICBPUkRFUiBCWSBgQ2FzZSBOb3RlIERvY3VtZW50IFB1Ymxpc2ggUHVibGlzaGluZyBEYXRlIFRpbWVgIERFU0MKIiIiKSk=\").decode())\n\ntry:\n    # run user code\n    __backend_agg_user_code_fn()\n\n    #reset display function\n    display = __backend_agg_display_orig\n\n    if len(__backend_agg_dfs) > 0:\n        # create a temp view\n        if type(__backend_agg_dfs[0]).__module__ == \"databricks.koalas.frame\":\n            # koalas dataframe\n            __backend_agg_dfs[0].to_spark().createOrReplaceTempView(\"DatabricksVieweb54462\")\n        elif type(__backend_agg_dfs[0]).__module__ == \"pandas.core.frame\" or isinstance(__backend_agg_dfs[0], list):\n            # pandas dataframe\n            spark.createDataFrame(__backend_agg_dfs[0]).createOrReplaceTempView(\"DatabricksVieweb54462\")\n        else:\n            __backend_agg_dfs[0].createOrReplaceTempView(\"DatabricksVieweb54462\")\n        #run backend agg\n        display(spark.sql(\"\"\"WITH q AS (select * from DatabricksVieweb54462) SELECT `RunID`,COUNT(`CDAM Call Status`) `column_1d11d9df473`,`CDAM Call Status` FROM q GROUP BY `CDAM Call Status`,`RunID`\"\"\"))\n    else:\n        displayHTML(\"dataframe no longer exists. If you're using dataframe.display(), use display(dataframe) instead.\")\n\n\nfinally:\n    spark.sql(\"drop view if exists DatabricksVieweb54462\")\n    display = __backend_agg_display_orig\n    del __backend_agg_display_new\n    del __backend_agg_display_orig\n    del __backend_agg_dfs\n    del __backend_agg_user_code_fn\n\n",
        "commandTitle": "Visualization Results",
        "commandType": "auto",
        "commandVersion": 0,
@@ -536,7 +569,7 @@
        "errorDetails": null,
        "errorSummary": null,
        "errorTraceType": null,
-       "finishTime": 1777467587727,
+       "finishTime": 1779361726721,
        "globalVars": {},
        "guid": "",
        "height": "auto",
@@ -568,7 +601,7 @@
        "resultDbfsStatus": "INLINED_IN_TREE",
        "results": null,
        "showCommandTitle": true,
-       "startTime": 1777467585824,
+       "startTime": 1779361724749,
        "state": "input",
        "streamStates": {},
        "subcommandOptions": {
@@ -607,7 +640,7 @@
          ]
         }
        },
-       "submitTime": 1777467585776,
+       "submitTime": 1779361711536,
        "subtype": "tableResultSubCmd.visualization",
        "tableResultIndex": 0,
        "tableResultSettingsMap": {},
@@ -660,12 +693,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1777467304865,
+     "finishTime": 1779361731847,
      "inputWidgets": {},
      "nuid": "65276071-fd55-4f13-8ca4-6acd034a6d10",
      "showTitle": true,
-     "startTime": 1777467301743,
-     "submitTime": 1777467294754,
+     "startTime": 1779361726728,
+     "submitTime": 1779361711531,
      "tableResultSettingsMap": {
       "0": {
        "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{\"Case Note Document File URL\":{\"format\":{\"preset\":\"string-preset-url\",\"locale\":\"en\"}},\"CDAM document_url\":{\"format\":{\"preset\":\"string-preset-url\",\"locale\":\"en\"}}}},\"syncTimestamp\":1777464211122}",
@@ -729,13 +762,20 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1777467309190,
+     "finishTime": 1779361737681,
      "inputWidgets": {},
      "nuid": "0ca2c2ec-3d5a-4fbd-bc54-b2976d511619",
      "showTitle": true,
-     "startTime": 1777467304881,
-     "submitTime": 1777467294757,
-     "tableResultSettingsMap": {},
+     "startTime": 1779361731862,
+     "submitTime": 1779361711546,
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{\"ind\":90},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1779362245737}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
      "title": "Counts across tables"
     }
    },
@@ -795,12 +835,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1777467309289,
+     "finishTime": 1779361738483,
      "inputWidgets": {},
      "nuid": "0614573a-f693-44fb-bbe2-6abcd7883060",
      "showTitle": false,
-     "startTime": 1777467309202,
-     "submitTime": 1777467294769,
+     "startTime": 1779361737697,
+     "submitTime": 1779361711550,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -825,9 +865,9 @@
        "options": null,
        "position": {
         "height": 6,
-        "width": 12,
+        "width": 24,
         "x": 0,
-        "y": 18,
+        "y": 16,
         "z": null
        },
        "resultIndex": null
@@ -840,24 +880,9 @@
        "options": null,
        "position": {
         "height": 6,
-        "width": 12,
+        "width": 24,
         "x": 0,
-        "y": 12,
-        "z": null
-       },
-       "resultIndex": null
-      },
-      {
-       "dashboardResultIndex": null,
-       "elementNUID": "60ca5701-f246-44d2-8532-169ace5bd291",
-       "elementType": "command",
-       "guid": "952c4c22-f66e-456e-8e86-eed079409ca6",
-       "options": null,
-       "position": {
-        "height": 6,
-        "width": 12,
-        "x": 0,
-        "y": 6,
+        "y": 10,
         "z": null
        },
        "resultIndex": null
@@ -867,10 +892,31 @@
        "elementNUID": "95b5e06e-a239-40e1-add1-fa3f6957c3b2",
        "elementType": "command",
        "guid": "b0268b64-c7b5-4b20-8f9b-dd24b6e6ec81",
+       "options": {
+        "autoScaleImg": false,
+        "scale": 0,
+        "showTitle": true,
+        "title": "Count of Publish and Response from CDAM",
+        "titleAlign": "center"
+       },
+       "position": {
+        "height": 5,
+        "width": 24,
+        "x": 0,
+        "y": 5,
+        "z": null
+       },
+       "resultIndex": null
+      },
+      {
+       "dashboardResultIndex": 0,
+       "elementNUID": "0ca2c2ec-3d5a-4fbd-bc54-b2976d511619",
+       "elementType": "command",
+       "guid": "c7a79c55-eb0b-40e9-8c13-0b92604a83b7",
        "options": null,
        "position": {
-        "height": 6,
-        "width": 12,
+        "height": 5,
+        "width": 24,
         "x": 0,
         "y": 0,
         "z": null
@@ -885,10 +931,10 @@
       "stack": true
      },
      "nuid": "460527ac-f6c6-44a4-bca1-ba672fcab2ae",
-     "origId": 5019491703245773,
+     "origId": 7020325546713885,
      "title": "CDAM Tracking Dashboard",
      "version": "DashboardViewV1",
-     "width": 2048
+     "width": 1024
     }
    ],
    "environmentMetadata": {


### PR DESCRIPTION
Updating the CDAM Dashboard to be more user friendly and easier to interpret. The counts from segmentation -> HTML generation -> Publish -> Acknowledge are shown first. A count of successful/failed publish/response are then shown as a quick aid. Finally, the full tables for both queries are returned. If any failures exist, it's quick to diagnose which record contained the error and failed.
