### PR TITLE
Tighten DQ Rules for AddressLine1AdminJ, AddressLine2AdminJ

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
@@ -840,7 +840,8 @@ class paymentPendingDQRules(DQRulesBase):
                     AND
                     addressLine1AdminJ IS NOT NULL
                 )
-                OR (addressLine1AdminJ IS NULL)
+                OR (NOT array_contains(valid_categoryIdList, 38) AND addressLine1AdminJ IS NULL)
+                OR (valid_categoryIdList IS NULL AND addressLine1AdminJ IS NULL)
             )"""
         )
 
@@ -854,7 +855,8 @@ class paymentPendingDQRules(DQRulesBase):
                     AND
                     addressLine2AdminJ IS NOT NULL
                 )
-                OR (addressLine2AdminJ IS NULL)
+                OR (NOT array_contains(valid_categoryIdList, 38) AND addressLine2AdminJ IS NULL)
+                OR (valid_categoryIdList IS NULL AND addressLine2AdminJ IS NULL)
             )"""
         )
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ARIADM-2210

Tighten DQ Rules for AddressLine1AdminJ, AddressLine2AdminJ. Additional checks include:
1. If the CategoryIdList != 38, AddressLineAdminJ must be null
2. If the CategoryIdList IS NULL, AddressLineAdminJ must be null

This catches the edge cases missing before, due to the missing data

All of AddressLine1AdminJ passes (as expected). One failed DQ currently for AddressLine2AdminJ (as expected)
