### PR TITLE
Update recordedOutOfTimeDecision logic per 2054

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -364,7 +364,11 @@ def caseData(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, 
     ).withColumn(
         "tribunalReceivedDate", date_format(col("m1.DateAppealReceived"), "yyyy-MM-dd")
     ).withColumn(
-        "recordedOutOfTimeDecision",when((col("OutOfTimeIssue") == True) & (col("Outcome") != 0), lit("Yes")).otherwise(None)
+        "recordedOutOfTimeDecision", when((col("m1.dv_TargetState").isin(["paymentPending", "appealSubmitted"]))
+            & (col("m1.OutOfTimeIssue") == True) & (col("m3.Outcome").isNotNull()),lit("Yes"))
+        
+        .when((~col("m1.dv_TargetState").isin(["paymentPending", "appealSubmitted"])) & (col("m1.OutOfTimeIssue") == True), lit("Yes"))
+        .otherwise(None)
     ).withColumn(
         "outOfTimeDecisionType",when((col("OutOfTimeIssue") == True) & (col("Outcome") != 0), lit("approved")).otherwise(None)
     ).withColumn(

--- a/tests/active/paymentPending/caseData_test.py
+++ b/tests/active/paymentPending/caseData_test.py
@@ -19,6 +19,7 @@ def caseData_outputs(spark):
     # -------------------------------
     m1_schema = T.StructType([
         T.StructField("CaseNo", T.StringType(), True),
+        T.StructField("dv_TargetState", T.StringType(), True),
         T.StructField("dv_representation", T.StringType(), True),
         T.StructField("lu_appealType", T.StringType(), True),
         T.StructField("CentreId", T.IntegerType(), True),
@@ -150,34 +151,34 @@ def caseData_outputs(spark):
     # Assign CentreId to match bronze_hearing_centres
     m1_data = [
     # EA/10544/2022 – Birmingham
-    ("EA/10544/2022", "AIP", "euSettlementScheme", 520, None, None, "0", None, False,
+    ("EA/10544/2022", "listing", "AIP", "euSettlementScheme", 520, None, None, "0", None, False,
      datetime(2022,10,20), datetime(2022,10,20),
      "birmingham", "Birmingham", {"region":"1","baseLocation":"231596"}, dv_hearingCentreDynamicList, dv_caseManagementLocationRefData, lu_selectedHearingCentre_birmingham),
 
     # HU/00516/2025 – Bradford
-    ("HU/00516/2025", "LR", "refusalOfHumanRights", 86, "S06 7UR", None, "0", None, False,
+    ("HU/00516/2025", "appealSubmitted", "LR", "refusalOfHumanRights", 86, "S06 7UR", None, "0", None, False,
      datetime(2025,2,28), datetime(2025,2,28),
      "bradford", "Bradford", {"region":None,"baseLocation":None}, dv_hearingCentreDynamicList, dv_caseManagementLocationRefData, lu_selectedHearingCentre_bradford),
 
     # EA/01698/2024 – Hatton Cross (migrated ARIA)
-    ("EA/01698/2024", "LR", "euSettlementScheme", 386417, None, None, "0",
+    ("EA/01698/2024", "appealSubmitted", "LR", "euSettlementScheme", 386417, None, None, "0",
      "This is an ARIA Migrated Case.", True,
      datetime(2024,7,31), datetime(2024,7,31),
      "hattonCross", "Hatton Cross", {"region":None,"baseLocation":None}, dv_hearingCentreDynamicList, dv_caseManagementLocationRefData, lu_selectedHearingCentre_hatton),
 
     # HU/00240/2022 – Manchester
-    ("HU/00240/2022", "LR", "refusalOfHumanRights", 512401, None, "WN4R 8ET", "0", None, False,
+    ("HU/00240/2022", "appealSubmitted", "LR", "refusalOfHumanRights", 512401, None, "WN4R 8ET", "0", None, False,
      datetime(2021,11,4), datetime(2021,11,4),
      "manchester", "Manchester", {"region":None,"baseLocation":None}, dv_hearingCentreDynamicList, dv_caseManagementLocationRefData, lu_selectedHearingCentre_manchester),
 
     # HU/00576/2025 – Taylor House
-    ("HU/00576/2025", "AIP", "refusalOfHumanRights", 765324, None, None, "0",
+    ("HU/00576/2025", "appealSubmitted", "AIP", "refusalOfHumanRights", 765324, None, None, "0",
      "This is a migrated ARIA case. Please refer to the documents.", True,
      datetime(2025,4,1), datetime(2025,4,1),
      "taylorHouse", "Taylor House", {"region":"1","baseLocation":"765324"}, dv_hearingCentreDynamicList, dv_caseManagementLocationRefData, lu_selectedHearingCentre_taylor),
 
     # HU/00366/2025 – Fully missing / unresolved
-    ("HU/00366/2025", "AIP", "refusalOfHumanRights", None, None, None, "0",
+    ("HU/00366/2025", "appealSubmitted", "AIP", "refusalOfHumanRights", None, None, None, "0",
      None, False,
      datetime(2024,11,6), datetime(2024,11,6),
      None, None, {"region":None,"baseLocation":None}, dv_hearingCentreDynamicList, dv_caseManagementLocationRefData, lu_selectedHearingCentre_placeholder),
@@ -221,11 +222,11 @@ def caseData_outputs(spark):
     ])
 
     silver_h_data = [
-        ("HU/00140/2024", 117070534, 49, "XXXXXXXXXXXXXXXX", "paymentPending"),
-        ("HU/00516/2025", 118350122, 18, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "paymentPending"),
-        ("EA/02375/2024", 117941932, 20, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "paymentPending"),
-        ("EA/04437/2020", 111949213, 18, "XXXXXXXXXX", "paymentPending"),
-        ("EA/10544/2022", 115591725, 16, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "paymentPending"),
+        ("HU/00140/2024", 117070534, 49, "XXXXXXXXXXXXXXXX", "appealSubmitted"),
+        ("HU/00516/2025", 118350122, 18, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "appealSubmitted"),
+        ("EA/02375/2024", 117941932, 20, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "appealSubmitted"),
+        ("EA/04437/2020", 111949213, 18, "XXXXXXXXXX", "appealSubmitted"),
+        ("EA/10544/2022", 115591725, 16, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "listing"),
     ]
 
     bronze_hearing_centres_schema = T.StructType([


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ARIADM-2054

The previous logic was not designed correctly. I have updated the logic to account for the discrepancies between states i.e. only apply: "IF M1.OutOfTime ==1 AND M3.Outcome IS NOT NULL for the MAX(StatusId)" when in paymentPending or appealSubmitted state, otherwise 
"(b) All other states:
IF M1.OutOfTime == 1"

I have tested using PP, APS and listing pipeline. Outputs are producing results as expected and fixing errors with known caseNos.
