### PR TITLE
Fixed conditionals for paidDate, paidAmount and additionalPaymentInfo

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/appealSubmitted.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/appealSubmitted.py
@@ -25,17 +25,14 @@ def paymentType(silver_m1, silver_m4):
 
     conditions_all = col("dv_CCDAppealType").isin(["EA", "EU", "HU", "PA"])
 
-    ref_txn_df = (
+    filtered_rows = silver_m4.alias("t").join(
         silver_m4.filter(~col("TransactionTypeId").isin(6, 19))
         .select("ReferringTransactionId")
         .where(col("ReferringTransactionId").isNotNull())
         .distinct()
-    )
-
-    filtered_rows = silver_m4.alias("t").join(
-        ref_txn_df.alias("r"),
+        .alias("r"),
         col("t.TransactionId") == col("r.ReferringTransactionId"),
-        "left_anti", #not in
+        "left_anti",
     )
 
     valid_cases = (
@@ -51,7 +48,7 @@ def paymentType(silver_m1, silver_m4):
 
     final_filtered_df = filtered_rows.join(valid_cases, "CaseNo", "inner")
 
-    ref_txn_df1 = (
+    ref_txn_df = (
         silver_m4.filter(col("TransactionTypeId").isin(6, 19))
         .select("ReferringTransactionId")
         .where(col("ReferringTransactionId").isNotNull())
@@ -60,7 +57,7 @@ def paymentType(silver_m1, silver_m4):
 
     payment_status = (
         silver_m4.alias("m4")
-        .join(ref_txn_df1.alias("r_txn"),
+        .join(ref_txn_df.alias("r_txn"),
             col("m4.TransactionId") == col("r_txn.ReferringTransactionId"),
             "left_anti")
         .filter(col("SumBalance") == True)
@@ -103,6 +100,7 @@ def paymentType(silver_m1, silver_m4):
         .join(silver_m1, ["CaseNo"], "left")
         .join(paid_amount, ["CaseNo"], "left")
         .join(payment_status.alias("payment_status"), ["CaseNo"], "left")
+        .join(valid_cases.withColumn("has_valid_txn", lit(True)), ["CaseNo"], "left")
         .select(
             "payment_content.*",
             when(
@@ -125,19 +123,15 @@ def paymentType(silver_m1, silver_m4):
             )
             .alias("rpDcAppealHearingOption"),
             when(
-                conditions_all, date_format(col("DateCorrectFeeReceived"), "yyyy-MM-dd")
+                conditions_all & col("has_valid_txn"), date_format(col("DateCorrectFeeReceived"), "yyyy-MM-dd")
             ).alias("paidDate"),
             when(
-                conditions_all,
-                (
-                    when(col("paidAmount").isNotNull(), col("paidAmount"))
-                    .otherwise(lit(0))
-                    .cast(IntegerType())
-                    .cast(StringType())
-                ),
+                conditions_all & col("has_valid_txn"),
+                when(col("paidAmount").isNotNull(), col("paidAmount").cast(IntegerType()).cast(StringType()))
+                .otherwise(lit("0")),
             ).alias("paidAmount"),
             when(
-                conditions_all,
+                conditions_all & col("has_valid_txn"),
                 lit(
                     "This is an ARIA Migrated Case. The payment was made in ARIA and the payment history can be found in the case notes."
                 ),

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/appealSubmitted_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/appealSubmitted_dq_rules.py
@@ -150,13 +150,27 @@ class appealSubmittedDQRules(DQRulesBase):
         )
 
         checks["valid_paidDate"] = (
-            "((dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA') AND (paidDate IS NOT NULL OR paidDate IS NULL)) OR (dv_CCDAppealType IS NULL OR dv_CCDAppealType NOT IN ('EA', 'EU', 'HU', 'PA') AND paidDate IS NULL))"
+            """(
+                (
+                    dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA')
+                    AND SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 3 AND NOT ARRAY_CONTAINS(lu_ref_txn, x.TransactionId))) > 0
+                )
+                OR
+                (
+                    (
+                        dv_CCDAppealType IS NULL OR dv_CCDAppealType NOT IN ('EA', 'EU', 'HU', 'PA')
+                        OR NOT SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 3 AND NOT ARRAY_CONTAINS(lu_ref_txn, x.TransactionId))) > 0
+                    )
+                    AND paidDate IS NULL
+                )
+            )"""
         )
 
         checks["valid_paidAmount"] = (
             """(
                 (
                     (dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA'))
+                    AND SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 3 AND NOT ARRAY_CONTAINS(lu_ref_txn, x.TransactionId))) > 0
                     AND
                     (paidAmount <=> (
                         CAST(ABS(CAST(AGGREGATE(
@@ -173,6 +187,13 @@ class appealSubmittedDQRules(DQRulesBase):
                 )
                 OR
                 (
+                    (dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA'))
+                    AND NOT SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 3 AND NOT ARRAY_CONTAINS(lu_ref_txn, x.TransactionId))) > 0
+                    AND
+                    (paidAmount IS NULL)
+                )
+                OR
+                (
                     (dv_CCDAppealType IS NULL OR dv_CCDAppealType NOT IN ('EA', 'EU', 'HU', 'PA'))
                     AND
                     (paidAmount IS NULL)
@@ -181,7 +202,24 @@ class appealSubmittedDQRules(DQRulesBase):
         )
 
         checks["valid_additionalPaymentInfo"] = (
-            "((dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA') AND additionalPaymentInfo <=> 'This is an ARIA Migrated Case. The payment was made in ARIA and the payment history can be found in the case notes.') OR (dv_CCDAppealType IS NULL OR dv_CCDAppealType NOT IN ('EA', 'EU', 'HU', 'PA') AND additionalPaymentInfo IS NULL))"
+            """(
+                (
+                    dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA')
+                    AND SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 3 AND NOT ARRAY_CONTAINS(lu_ref_txn, x.TransactionId))) > 0
+                    AND additionalPaymentInfo <=> 'This is an ARIA Migrated Case. The payment was made in ARIA and the payment history can be found in the case notes.'
+                )
+                OR
+                (
+                    dv_CCDAppealType IS NOT NULL AND dv_CCDAppealType IN ('EA', 'EU', 'HU', 'PA')
+                    AND NOT SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 3 AND NOT ARRAY_CONTAINS(lu_ref_txn, x.TransactionId))) > 0
+                    AND additionalPaymentInfo IS NULL
+                )
+                OR
+                (
+                    (dv_CCDAppealType IS NULL OR dv_CCDAppealType NOT IN ('EA', 'EU', 'HU', 'PA'))
+                    AND additionalPaymentInfo IS NULL
+                )
+            )"""
         )
 
         checks["valid_paymentDescription"] = (

--- a/tests/active/appealSubmitted/aps_paymentType_test.py
+++ b/tests/active/appealSubmitted/aps_paymentType_test.py
@@ -87,7 +87,7 @@ class TestAppealSubmittedPaymentType:
                 ("3", 3, 1, 0.0, True, False, 3),     # valid condition
                 ("4", 3, 1, 0.0, True, False, 3),     # valid condition
                 ("5", 3, 1, 0.0, True, False, 3),     # valid condition
-                ("6", 3, 1, 0.0, False, False, 3),     # SumBalance = 0
+                ("6", 3, 1, 0.0, False, False, 3),    # SumBalance = 0
                 ("7", 1, 1, 0.0, True, False, 3),     # TransactionId = 1
                 ("8", 2, 1, 0.0, True, False, 3),     # TransactionId = 2
                 ("9", 3, 1, 100.0, True, False, 3),   # Amount > 0
@@ -96,7 +96,7 @@ class TestAppealSubmittedPaymentType:
                 ("11", 6, 19, 0.0, True, False, 2),   # Case 11 - TransactionTypeId = 19, TransactionId = 6
                 ("11", 7, 1, 0.0, True, False, 3),    # Case 11 - TransactionTypeId = 1, TransactionId = 7
                 ("12", 8, 1, 100.0, True, False, 0),  # Case 12 - TransactionTypeId = 1, TransactionId = 8
-                ("12", 9, 19, 0.0, False, False, 8)    # Case 12 - TransactionTypeId = 19, TransactionId = 9, ReferringTransaction 8, SumBalance = 0
+                ("12", 9, 19, 0.0, False, False, 8)   # Case 12 - TransactionTypeId = 19, TransactionId = 9, ReferringTransaction 8, SumBalance = 0
             ]
 
             silver_m1 = spark.createDataFrame(m1_data, self.SILVER_M1_SCHEMA)
@@ -195,18 +195,32 @@ class TestAppealSubmittedPaymentType:
 
     def test_paidDate(self, spark):
         with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.paymentType.return_value = self.payment_pending_df(spark, 5)
+            PP.paymentType.return_value = self.payment_pending_df(spark, 7)
 
             m1_data = [
-                ("1", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case - paidDate set
-                ("2", "EU", "LR", 0, datetime(2000, 2, 5)),    # EU Case - paidDate set
-                ("3", "HU", "AIP", 0, datetime(2000, 3, 10)),  # HU Case - paidDate set
-                ("4", "PA", "LR", 0, datetime(2000, 4, 15)),   # PA Case - paidDate set
-                ("5", "RP", "AIP", 0, datetime(2000, 1, 1))    # RP Case - none
+                ("1", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case - in valid_cases, paidDate set
+                ("2", "EU", "LR", 0, datetime(2000, 2, 5)),    # EU Case - in valid_cases, paidDate set
+                ("3", "HU", "AIP", 0, datetime(2000, 3, 10)),  # HU Case - in valid_cases, paidDate set
+                ("4", "PA", "LR", 0, datetime(2000, 4, 15)),   # PA Case - in valid_cases, paidDate set
+                ("5", "RP", "AIP", 0, datetime(2000, 1, 1)),   # RP Case - none
+                ("6", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case with no txn = 3
+                ("7", "EA", "AIP", 0, datetime(2000, 1, 1))    # EA Case with transactionTypeId not in 6 or 19
+            ]
+
+            m4_data = [
+                ("98", 1, 6, 100.0, False, False, 1),   # TransactionTypeId = 6, ReferringTransationId = 1
+                ("99", 1, 19, 100.0, False, False, 2),  # TransactionTypeId = 19, ReferringTransationId = 2
+                ("1", 1, 3, 0.0, False, False, 3),      # txn = 3 and valid
+                ("2", 2, 3, 0.0, False, False, 3),      # txn = 3 and valid
+                ("3", 1, 3, 0.0, False, False, 3),      # txn = 3 and valid
+                ("4", 2, 3, 0.0, False, False, 3),      # txn = 3 and valid
+                ("5", 1, 3, 0.0, False, False, 3),      # txn = 3 not valid
+                ("6", 2, 10, 0.0, False, False, 3),     # txn != 3 not valid
+                ("7", 3, 3, 0.0, False, False, 3)       # txn = 3 but TransactionId not part of ReferringTransactionId in (6, 19) not valid
             ]
 
             silver_m1 = spark.createDataFrame(m1_data, self.SILVER_M1_SCHEMA)
-            silver_m4 = spark.createDataFrame([], self.SILVER_M4_SCHEMA)
+            silver_m4 = spark.createDataFrame(m4_data, self.SILVER_M4_SCHEMA)
 
             df, df_audit = paymentType(silver_m1, silver_m4)
 
@@ -214,11 +228,12 @@ class TestAppealSubmittedPaymentType:
 
             assert resultList[0][0] == "2000-01-01" and resultList[1][0] == "2000-02-05"
             assert resultList[2][0] == "2000-03-10" and resultList[3][0] == "2000-04-15"
-            assert resultList[4][0] is None
+            assert resultList[4][0] is None and resultList[5][0] is None
+            assert resultList[6][0] is None
 
     def test_paidAmount(self, spark):
         with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.paymentType.return_value = self.payment_pending_df(spark, 9)
+            PP.paymentType.return_value = self.payment_pending_df(spark, 10)
 
             m1_data = [
                 ("1", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case with valid condition - paidAmount set
@@ -227,25 +242,27 @@ class TestAppealSubmittedPaymentType:
                 ("4", "PA", "LR", 0, datetime(2000, 4, 15)),   # PA Case with valid condition - paidAmount set
                 ("5", "RP", "AIP", 0, datetime(2000, 1, 1)),   # RP Case - none
                 ("6", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case with SumTotalPay = 0 - 0 set
-                ("7", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case with ReferringTransactionId = TransactionId with Type in 6 - 0 set
-                ("8", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case with ReferringTransactionId = TransactionId with Type in 19 - 0 set
-                ("9", "EA", "AIP", 0, datetime(2000, 1, 1))    # EA Case with valid condition and multiple transactions - sum paidAmount set
+                ("7", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case without ReferringTransactionId = TransactionId with Type in 6 - null
+                ("8", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case without ReferringTransactionId = TransactionId with Type in 19 - null
+                ("9", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case with valid condition and multiple transactions - sum paidAmount set
+                ("10", "EA", "AIP", 0, datetime(2000, 1, 1))   # EA Case with no TransactionTypeId = 3
             ]
 
             m4_data = [
                 ("98", 1, 6, 100.0, False, True, 1),   # TransactionTypeId = 6, ReferringTransationId = 1
                 ("99", 1, 19, 100.0, False, True, 2),  # TransactionTypeId = 19, ReferringTransationId = 2
-                ("1", 3, 1, 100.0, False, True, 3),    # valid condition
-                ("2", 3, 3, 100.0, False, True, 3),    # valid condition
-                ("3", 2, 3, 100.0, False, True, 1),    # valid condition
-                ("4", 2, 1, 100.0, False, True, 3),    # valid condition
-                ("5", 3, 1, 100.0, False, True, 3),    # valid condition
-                ("6", 3, 1, 100.0, False, False, 3),    # SumTotalPay = 0
-                ("7", 1, 1, 100.0, False, True, 3),    # TransactionId = 1
-                ("8", 2, 1, 100.0, False, True, 3),    # TransactionId = 2
-                ("9", 3, 1, 100.0, False, True, 3),    # valid condition for same case
-                ("9", 3, 1, 150.0, False, True, 3),    # valid condition for same case
-                ("9", 3, 3, 250.0, False, True, 3)     # valid condition for same case
+                ("1", 1, 3, 100.0, False, True, 3),    # valid condition
+                ("2", 2, 3, 100.0, False, True, 3),    # valid condition
+                ("3", 1, 3, 100.0, False, True, 3),    # valid condition
+                ("4", 2, 3, 100.0, False, True, 3),    # valid condition
+                ("5", 1, 3, 100.0, False, True, 3),    # valid condition but not valid appealType
+                ("6", 2, 3, 100.0, False, False, 3),   # SumTotalPay = 0
+                ("7", 3, 3, 100.0, False, True, 3),    # TransactionId not in ReferringTransationId
+                ("8", 3, 3, 100.0, False, True, 3),    # TransactionId not in ReferringTransationId
+                ("9", 1, 1, 100.0, False, True, 3),    # valid condition for same case
+                ("9", 2, 2, 150.0, False, True, 3),    # valid condition for same case
+                ("9", 1, 3, 250.0, False, True, 3),    # valid condition for same case
+                ("10", 1, 10, 250.0, False, True, 3)   # TransactionTypeId != 3
             ]
 
             silver_m1 = spark.createDataFrame(m1_data, self.SILVER_M1_SCHEMA)
@@ -255,30 +272,38 @@ class TestAppealSubmittedPaymentType:
 
             resultList = df.orderBy(col("CaseNo").cast("int")).select("paidAmount").collect()
 
-            assert resultList[0][0] == "0" 
-            assert resultList[1][0] == "0" 
-            assert resultList[2][0] == "100" 
-            assert resultList[3][0] == "0" 
+            assert resultList[0][0] == "100"
+            assert resultList[1][0] == "100"
+            assert resultList[2][0] == "100"
+            assert resultList[3][0] == "100"
             assert resultList[4][0] is None
             assert resultList[5][0] == "0"
-            assert resultList[6][0] == "0"
-            assert resultList[7][0] == "0" 
-            assert resultList[8][0] == "0"
+            assert resultList[6][0] is None
+            assert resultList[7][0] is None
+            assert resultList[8][0] == "500"
+            assert resultList[9][0] is None
 
     def test_additionalPaymentInfo(self, spark):
         with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
             PP.paymentType.return_value = self.payment_pending_df(spark, 5)
 
             m1_data = [
-                ("1", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case - additionalPaymentInfo set
-                ("2", "EU", "LR", 0, datetime(2000, 1, 1)),    # EU Case - additionalPaymentInfo set
-                ("3", "HU", "AIP", 0, datetime(2000, 1, 1)),  # HU Case - additionalPaymentInfo set
-                ("4", "PA", "LR", 0, datetime(2000, 1, 1)),   # PA Case - additionalPaymentInfo set
+                ("1", "EA", "AIP", 0, datetime(2000, 1, 1)),   # EA Case - in valid_cases, additionalPaymentInfo set
+                ("2", "EU", "LR", 0, datetime(2000, 1, 1)),    # EU Case - in valid_cases, additionalPaymentInfo set
+                ("3", "HU", "AIP", 0, datetime(2000, 1, 1)),   # HU Case - in valid_cases, additionalPaymentInfo set
+                ("4", "PA", "LR", 0, datetime(2000, 1, 1)),    # PA Case - in valid_cases, additionalPaymentInfo set
                 ("5", "RP", "AIP", 0, datetime(2000, 1, 1))    # RP Case - none
+            ]
+            
+            m4_data = [
+                ("1", 10, 3, 0.0, False, False, 99),
+                ("2", 11, 3, 0.0, False, False, 99),
+                ("3", 12, 3, 0.0, False, False, 99),
+                ("4", 13, 3, 0.0, False, False, 99),
             ]
 
             silver_m1 = spark.createDataFrame(m1_data, self.SILVER_M1_SCHEMA)
-            silver_m4 = spark.createDataFrame([], self.SILVER_M4_SCHEMA)
+            silver_m4 = spark.createDataFrame(m4_data, self.SILVER_M4_SCHEMA)
 
             df, df_audit = paymentType(silver_m1, silver_m4)
 


### PR DESCRIPTION
Added the conditional

SELECT CaseNo
FROM M4
WHERE 
TransactionID NOT IN 
(SELECT ReferringTransactionId FROM M4
  WHERE TransactionTypeId NOT IN (6,19)) 
GROUP BY CaseNo
HAVING 
       SUM(CASE WHEN TransactionTypeID = 3 THEN 1 ELSE 0 END) > 0

To paidDate, paidAmount and additionalPaymentInfo fields in appealSubmitted.