### PR TITLE
Updated appellantInUk and appealOutOfCountry logic

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpendingDetained_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpendingDetained_dq_rules.py
@@ -396,18 +396,18 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         # ##############################
 
         checks["valid_appellantInUk"] = ("""
-            CASE    WHEN Detained IN (1,2,4) OR array_contains(valid_categoryIdList, 37) THEN appellantInUk = 'Yes'
+            CASE    WHEN Detained IN (1,2,4) THEN appellantInUk = 'Yes'
+                    WHEN array_contains(valid_categoryIdList, 37) THEN appellantInUk = 'Yes'
                     WHEN array_contains(valid_categoryIdList, 38) THEN appellantInUk = 'No'
-                    ELSE appellantInUk IS  NULL
+                    ELSE appellantInUk IN ('Yes', 'No')
             END
         """)
 
         checks["valid_appealOutOfCountry"] = ("""
-            CASE    WHEN Detained IN (1,2,4) OR array_contains(valid_categoryIdList, 37) THEN appealOutOfCountry = 'No'
-                    WHEN array_contains(valid_categoryIdList, 38) THEN appealOutOfCountry = 'Yes'
-                    ELSE appealOutOfCountry IS  NULL
+            CASE    WHEN appellantInUk = 'Yes' THEN appealOutOfCountry = 'No'
+                    WHEN appellantInUk = 'No' THEN appealOutOfCountry = 'Yes'
+                    ELSE appealOutOfCountry IS NULL
             END
-
         """)
 
         ##############################

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1476,6 +1476,23 @@ def getCountryApp(country, ukPostcodeAppellant, appellantFullAddress, Appellant_
 
 getCountryApp_udf = udf(getCountryApp, StringType())
 
+def derive_country_silver_m2(silver_m2):
+    return (
+        silver_m2
+        .withColumn("appellantFullAddress", concat_ws(", ",
+            col("Appellant_Address1"), col("Appellant_Address2"),
+            col("Appellant_Address3"), col("Appellant_Address4"),
+            col("Appellant_Address5"), col("Appellant_Postcode")
+        ))
+        .withColumn("ukPostcodeAppellant", getUkPostcodeUDF(col("Appellant_Postcode")))
+        .withColumn("dv_countryGovUkOocAdminJ", getCountryApp_udf(
+            col("lu_countryGovUkOocAdminJ"),
+            col("ukPostcodeAppellant"),
+            col("appellantFullAddress"),
+            col("Appellant_Postcode")
+        ))
+    )
+
 def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, bronze_HORef_cleansing, bronze_nationalities):
     conditions = (col("dv_representation").isin('LR', 'AIP')) & (col("lu_appealType").isNotNull())
 
@@ -1651,29 +1668,8 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
     ).otherwise(None)
 
     silver_m2 = silver_m2.filter(col("Relationship").isNull())
-    
-    silver_m2_derived = silver_m2.withColumn(
-        "appellantFullAddress",
-            concat_ws(", ",
-                col("Appellant_Address1"),
-                col("Appellant_Address2"),
-                col("Appellant_Address3"),
-                col("Appellant_Address4"),
-                col("Appellant_Address5"),
-                col("Appellant_Postcode")
-            )
-    ).withColumn(
-        "ukPostcodeAppellant",
-        getUkPostcodeUDF(col("Appellant_Postcode"))
-    ).withColumn(
-        "dv_countryGovUkOocAdminJ",
-        getCountryApp_udf(
-            col("lu_countryGovUkOocAdminJ").alias("country"),
-            col("ukPostcodeAppellant"),
-            col("appellantFullAddress"),
-            col("Appellant_Postcode")
-        )
-    )
+
+    silver_m2_derived = derive_country_silver_m2(silver_m2)
 
     bronze_countries_countryFromAddress = bronze_countryFromAddress.withColumn("lu_cfa_countryGovUkOocAdminJ", col("countryGovUkOocAdminJ")).withColumn("lu_cfa_contryFromAddress", col("countryFromAddress"))
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1482,18 +1482,20 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
     # Create DataFrame with CaseNo and list of CategoryId
     silver_c_grouped = silver_c.groupBy("CaseNo").agg(collect_list(col("CategoryId")).alias("CategoryIdList"))
 
-    appellant_nationalities = silver_m1.join(bronze_nationalities, on="NationalityId", how="left"
-                    ).withColumn(
-                        "appellantStateless",
-                        when(conditions & (col("NationalityId") == 211), lit("isStateless"))
-                        .when(conditions, lit("hasNationality"))
-                        .otherwise(None)
-                    ).select("CaseNo", 
-                             "NationalityId",
-                             "Description",
-                             when(col("countryCode") == lit('NO MAPPING REQUIRED'), lit(None)).otherwise(col("countryCode")).alias("countryCode"),
-                             when(col("appellantNationalitiesDescription") == lit('NO MAPPING REQUIRED'), lit(None)).otherwise(col("appellantNationalitiesDescription")).alias("appellantNationalitiesDescription"),
-                             "appellantStateless")
+    appellant_nationalities = (silver_m1.join(bronze_nationalities, on="NationalityId", how="left")
+        .withColumn(
+            "appellantStateless",
+            when(conditions & (col("NationalityId") == 211), lit("isStateless"))
+            .when(conditions, lit("hasNationality"))
+            .otherwise(None)
+        ).select("CaseNo",
+            "NationalityId",
+            "Description",
+            when(col("countryCode") == lit('NO MAPPING REQUIRED'), lit(None)).otherwise(col("countryCode")).alias("countryCode"),
+            when(col("appellantNationalitiesDescription") == lit('NO MAPPING REQUIRED'), lit(None)).otherwise(col("appellantNationalitiesDescription")).alias("appellantNationalitiesDescription"),
+            "appellantStateless"
+        )
+    )
 
     # isAppellantMinor: BirthDate > (DateLodged - 18 years) using year subtraction
     is_minor_expr = when(
@@ -1516,16 +1518,14 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
     ).when(
         conditions & (expr("array_contains(CategoryIdList, 38)")), lit("No")
     ).when(
-        conditions & (upper(col("silver_m2.Appellant_Address5")).eqNullSafe("UK")), lit("Yes")
+        conditions & (col("dv_countryGovUkOocAdminJ").eqNullSafe("GB")), lit("Yes")
     ).when(
-        conditions & ~(upper(col("silver_m2.Appellant_Address5")).eqNullSafe("UK")), lit("No")
+        conditions & ~(col("dv_countryGovUkOocAdminJ").eqNullSafe("GB")), lit("No")
     ).otherwise(None)
 
     # appealOutOfCountry logic
-    appeal_out_of_country_expr = when(
-        conditions & (expr("array_contains(CategoryIdList, 38)")), lit("Yes")
-    ).otherwise(lit("No"))
-    
+    appeal_out_of_country_expr = when(appellant_in_uk_expr == lit("Yes"), lit("No")).when(appellant_in_uk_expr == lit("No"), lit("Yes")).otherwise(None)
+
     # appellantHasFixedAddress logic
     appellant_has_fixed_address_expr = when(
         conditions & expr("array_contains(CategoryIdList, 37)"), lit("Yes")
@@ -1651,28 +1651,29 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
     ).otherwise(None)
 
     silver_m2 = silver_m2.filter(col("Relationship").isNull())
-
-    silver_m2_derived = silver_m2.withColumn("appellantFullAddress",
-                                            concat_ws(", ",
-                                                col("Appellant_Address1"),
-                                                col("Appellant_Address2"),
-                                                col("Appellant_Address3"),
-                                                col("Appellant_Address4"),
-                                                col("Appellant_Address5"),
-                                                col("Appellant_Postcode")
-                                            )
-                                    ).withColumn(
-                                        "ukPostcodeAppellant",
-                                        getUkPostcodeUDF(col("Appellant_Postcode"))
-                                    ).withColumn(
-                                        "dv_countryGovUkOocAdminJ",
-                                        getCountryApp_udf(
-                                            col("lu_countryGovUkOocAdminJ").alias("country"),
-                                            col("ukPostcodeAppellant"),
-                                            col("appellantFullAddress"),
-                                            col("Appellant_Postcode")
-                                        )
-                                    )
+    
+    silver_m2_derived = silver_m2.withColumn(
+        "appellantFullAddress",
+            concat_ws(", ",
+                col("Appellant_Address1"),
+                col("Appellant_Address2"),
+                col("Appellant_Address3"),
+                col("Appellant_Address4"),
+                col("Appellant_Address5"),
+                col("Appellant_Postcode")
+            )
+    ).withColumn(
+        "ukPostcodeAppellant",
+        getUkPostcodeUDF(col("Appellant_Postcode"))
+    ).withColumn(
+        "dv_countryGovUkOocAdminJ",
+        getCountryApp_udf(
+            col("lu_countryGovUkOocAdminJ").alias("country"),
+            col("ukPostcodeAppellant"),
+            col("appellantFullAddress"),
+            col("Appellant_Postcode")
+        )
+    )
 
     bronze_countries_countryFromAddress = bronze_countryFromAddress.withColumn("lu_cfa_countryGovUkOocAdminJ", col("countryGovUkOocAdminJ")).withColumn("lu_cfa_contryFromAddress", col("countryFromAddress"))
 
@@ -1815,14 +1816,14 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
             lit("yes").alias("deportationOrderOptions_Transformation"),
 
             # Audit appellantInUk
-            array(struct(*common_inputFields, lit("CategoryId"))).alias("appellantInUk_inputfields"),
-            array(struct(*common_inputValues, col("CategoryIdList"))).alias("appellantInUk_inputvalues"),
+            array(struct(*common_inputFields, lit("CategoryId"), lit("dv_countryGovUkOocAdminJ"))).alias("appellantInUk_inputfields"),
+            array(struct(*common_inputValues, col("CategoryIdList"), col("audit.dv_countryGovUkOocAdminJ"))).alias("appellantInUk_inputvalues"),
             col("content.appellantInUk"),
             lit("yes").alias("appellantInUk_Transformation"),
 
             # Audit appealOutOfCountry
-            array(struct(*common_inputFields, lit("CategoryId"))).alias("appealOutOfCountry_inputfields"),
-            array(struct(*common_inputValues, col("CategoryIdList"))).alias("appealOutOfCountry_inputvalues"),
+            array(struct(*common_inputFields, lit("appellantInUk"))).alias("appealOutOfCountry_inputfields"),
+            array(struct(*common_inputValues, col("content.appellantInUk"))).alias("appealOutOfCountry_inputvalues"),
             col("content.appealOutOfCountry"),
             lit("yes").alias("appealOutOfCountry_Transformation"),
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
@@ -1,34 +1,24 @@
-from datetime import datetime
 import re
-import string
-import pycountry
-import pandas as pd
-import json
 
-from datetime import datetime
 from pyspark.sql import functions as F
-from pyspark.sql.window import Window
-from pyspark.sql.types import StringType,StructType,StructField
+from pyspark.sql.types import StringType, StructType, StructField
 from . import paymentPending as PP
 
-
 from pyspark.sql.functions import (
-    col, when, lit, array, struct, collect_list, 
-    max as spark_max, date_format, date_add, row_number, expr, regexp_replace,
-    size, udf, coalesce, concat_ws, concat, trim, year, split, datediff,
-    collect_set, current_timestamp,transform, first, array_contains,rank,create_map, map_from_entries, map_from_arrays
+    col, when, lit, array, struct, collect_list,
+    date_format, date_add, expr,
+    udf, coalesce, concat_ws, first
 )
+
 
 ################################################################
 ##########          Detained State Function          ###########
 ################################################################
+def detained(silver_m1, silver_m2, bronze_detention_centres):
 
-def detained(silver_m1, silver_m2,bronze_detention_centres):
-
-    joined_m1_m2 =(
+    joined_m1_m2 = (
         silver_m1.alias("m1")
         .join(silver_m2.alias("m2"), on="CaseNo", how="left")
-        
     )
 
     detained_df = (
@@ -150,16 +140,15 @@ def detained(silver_m1, silver_m2,bronze_detention_centres):
 
     return detained_df, detained_audit
 
+
 ################################################################
 ##########              caseData grouping            ###########
 ################################################################
-
-# caseData grouping
 def caseData(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres, bronze_detention_centres):
 
     case_mgmt_schema = StructType([
-    StructField("region", StringType(), True),
-    StructField("baseLocation", StringType(), True)
+        StructField("region", StringType(), True),
+        StructField("baseLocation", StringType(), True)
     ])
 
     bronze_detention_centres = bronze_detention_centres.withColumn(
@@ -237,13 +226,13 @@ def caseData(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, 
             col("selectedHearingCentreRefData1").alias("selectedHearingCentreRefData"),
         )
     ).distinct()
-    
+
     return caseData_df, caseData_audit
+
 
 ################################################################
 ##########             General Function              ###########
 ################################################################
-
 def general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres, bronze_detention_centres):
 
     general_df, general_audit = PP.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres)
@@ -261,7 +250,7 @@ def general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, b
         silver_m1.alias("m1")
         .join(silver_m2.alias("m2"), on="CaseNo", how="left")
         )
-    
+
     general_df = (
         general_df.alias("content").join(joined_m1_m2.alias("m2"),on="CaseNo", how="left")
         .join(bronze_detention_centres.alias("det"), on="DetentionCentreId", how="left")
@@ -294,16 +283,15 @@ def general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, b
                             array(struct(lit("None"),col("m2.DateLodged"))).alias("TTL_inputValues"),
                             col("content.TTL").alias("TTL_value"),
                             lit("Yes").alias("TTL_Transformation"),
-                            )
-                     
+                            )                
                      )
 
     return general_df, general_audit
 
+
 ################################################################
 ##########             appellantDetails Function              ###########
 ################################################################
-
 def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, bronze_HORef_cleansing, bronze_nationalities):
 
     appellantDetails_df, appellantDetails_audit = PP.appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, bronze_HORef_cleansing, bronze_nationalities)
@@ -313,21 +301,7 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
 
     silver_c_grouped = silver_c.groupBy("CaseNo").agg(collect_list(col("CategoryId")).alias("CategoryIdList"))
 
-    silver_m2_enriched = (
-        silver_m2
-        .withColumn("appellantFullAddress", concat_ws(", ",
-            col("Appellant_Address1"), col("Appellant_Address2"),
-            col("Appellant_Address3"), col("Appellant_Address4"),
-            col("Appellant_Address5"), col("Appellant_Postcode")
-        ))
-        .withColumn("ukPostcodeAppellant", PP.getUkPostcodeUDF(col("Appellant_Postcode")))
-        .withColumn("dv_countryGovUkOocAdminJ", PP.getCountryApp_udf(
-            col("lu_countryGovUkOocAdminJ"),
-            col("ukPostcodeAppellant"),
-            col("appellantFullAddress"),
-            col("Appellant_Postcode")
-        ))
-    )
+    silver_m2_enriched = PP.derive_country_silver_m2(silver_m2)
 
     appellantDetails_df = (
         appellantDetails_df.alias("content")
@@ -401,7 +375,7 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
 def cleanEmail(email):
     if email is None:
         return None
-    
+
     email = re.sub(r"\s+", "", email)             # Remove all whitespace
     email = re.sub(r"\s", "", email)              # 2. Remove internal whitespace
     email = re.sub(r"^\.", "", email)             # 3. Remove leading .

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
@@ -301,11 +301,11 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
 
     silver_c_grouped = silver_c.groupBy("CaseNo").agg(collect_list(col("CategoryId")).alias("CategoryIdList"))
 
-    silver_m2_enriched = PP.derive_country_silver_m2(silver_m2)
+    silver_m2_dervied = PP.derive_country_silver_m2(silver_m2)
 
     appellantDetails_df = (
         appellantDetails_df.alias("content")
-        .join(silver_m2_enriched.alias("m2"), on="CaseNo", how="left")
+        .join(silver_m2_dervied.alias("m2"), on="CaseNo", how="left")
         .join(silver_c_grouped.alias("mc"), on="CaseNo", how="left")
 
         # -----------------------------

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
@@ -308,15 +308,30 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
 
     appellantDetails_df, appellantDetails_audit = PP.appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, bronze_HORef_cleansing, bronze_nationalities)
 
-    appellantDetails_df = appellantDetails_df.drop("appellantInUk","appealOutOfCountry","appellantHasFixedAddress")
+    appellantDetails_df = appellantDetails_df.drop("appellantInUk", "appealOutOfCountry", "appellantHasFixedAddress")
     # appellantDetails_audit = appellantDetails_audit.drop("appellantAddress")
 
     silver_c_grouped = silver_c.groupBy("CaseNo").agg(collect_list(col("CategoryId")).alias("CategoryIdList"))
 
-    
+    silver_m2_enriched = (
+        silver_m2
+        .withColumn("appellantFullAddress", concat_ws(", ",
+            col("Appellant_Address1"), col("Appellant_Address2"),
+            col("Appellant_Address3"), col("Appellant_Address4"),
+            col("Appellant_Address5"), col("Appellant_Postcode")
+        ))
+        .withColumn("ukPostcodeAppellant", PP.getUkPostcodeUDF(col("Appellant_Postcode")))
+        .withColumn("dv_countryGovUkOocAdminJ", PP.getCountryApp_udf(
+            col("lu_countryGovUkOocAdminJ"),
+            col("ukPostcodeAppellant"),
+            col("appellantFullAddress"),
+            col("Appellant_Postcode")
+        ))
+    )
+
     appellantDetails_df = (
         appellantDetails_df.alias("content")
-        .join(silver_m2.alias("m2"), on="CaseNo", how="left")
+        .join(silver_m2_enriched.alias("m2"), on="CaseNo", how="left")
         .join(silver_c_grouped.alias("mc"), on="CaseNo", how="left")
 
         # -----------------------------
@@ -324,8 +339,11 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
         # -----------------------------
         .withColumn(
             "appellantInUk",
-            when(col("m2.Detained").isin(1, 2, 4) | expr("array_contains(CategoryIdList, 37)"), "Yes")
+            when(col("m2.Detained").isin(1, 2, 4), "Yes")
+            .when(expr("array_contains(CategoryIdList, 37)"), "Yes")
             .when(expr("array_contains(CategoryIdList, 38)"), "No")
+            .when(col("m2.dv_countryGovUkOocAdminJ").eqNullSafe("GB"), "Yes")
+            .when(~col("m2.dv_countryGovUkOocAdminJ").eqNullSafe("GB"), "No")
             .otherwise(None)
         )
 
@@ -334,8 +352,8 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
         # -----------------------------
         .withColumn(
             "appealOutOfCountry",
-            when(col("m2.Detained").isin(1, 2, 4) | expr("array_contains(CategoryIdList, 37)"), "No")
-            .when(expr("array_contains(CategoryIdList, 38)"), "Yes")
+            when(col("appellantInUk") == "Yes", "No")
+            .when(col("appellantInUk") == "No", "Yes")
             .otherwise(None)
         )
 

--- a/tests/active/paymentPending/appellantDetails_test.py
+++ b/tests/active/paymentPending/appellantDetails_test.py
@@ -119,11 +119,11 @@ def appellantDetails_outputs(spark):
         None, None, None, None, 4),
 
         ("HU/00004/2025", "WilliamsX", "SarahX", None, None,
-        None, None, None, None, "UK", None,
+        None, None, None, None, None, "SW1A 1AA",
         None, None, None, None, 0),
 
         ("HU/00005/2025", "WilliamsX", "SarahX", None, None,
-        None, None, None, None, "NotUK", None,
+        None, None, None, None, None, None,
         None, None, None, None, 0),
 
         # Marshall Islands (MH) — was previously mapped to NO MAPPING REQUIRED → NULL, now passes through as "MH"
@@ -340,8 +340,8 @@ def test_appellant_in_uk_field_conditions(appellantDetails_outputs):
     assert appellantDetails_outputs["HU/00001/2025"]["appellantInUk"] == "No"   # Detained 1 — no longer sets Yes in paymentPending
     assert appellantDetails_outputs["HU/00002/2025"]["appellantInUk"] == "No"   # Detained 2 — no longer sets Yes in paymentPending
     assert appellantDetails_outputs["HU/00003/2025"]["appellantInUk"] == "No"   # Detained 4 — no longer sets Yes in paymentPending
-    assert appellantDetails_outputs["HU/00004/2025"]["appellantInUk"] == "Yes"  # Appellant_Address5 in UK
-    assert appellantDetails_outputs["HU/00005/2025"]["appellantInUk"] == "No"   # Appellant_Address5 not in UK
+    assert appellantDetails_outputs["HU/00004/2025"]["appellantInUk"] == "Yes"  # valid UK postcode → dv_countryGovUkOocAdminJ = 'GB'
+    assert appellantDetails_outputs["HU/00005/2025"]["appellantInUk"] == "No"   # no postcode, no lu_countryGovUkOocAdminJ → dv_countryGovUkOocAdminJ != 'GB'
 
 
 def test_country_gov_uk_ooc_adminj_new_codes(appellantDetails_outputs):

--- a/tests/active/paymentPendingDetained/appellantDetails_test.py
+++ b/tests/active/paymentPendingDetained/appellantDetails_test.py
@@ -140,7 +140,7 @@ def test_detained_4_appellant_in_uk(appellantDetails_outputs):
 
 
 def test_detained_appeal_out_of_country(appellantDetails_outputs):
-    """Detained cases must produce appealOutOfCountry='No' regardless of other conditions."""
+    """Detained cases have appellantInUk='Yes', so appealOutOfCountry must be the inverse: 'No'."""
     assert appellantDetails_outputs["HU/DET/0001"]["appealOutOfCountry"] == "No"
     assert appellantDetails_outputs["HU/DET/0002"]["appealOutOfCountry"] == "No"
     assert appellantDetails_outputs["HU/DET/0003"]["appealOutOfCountry"] == "No"


### PR DESCRIPTION
Added country check for detained appellantInUk field and set the appealOutOfCountry to be opposite to appellantInUk

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [ARIADM-2024](https://tools.hmcts.net/jira/browse/ARIADM-2024)

### Change description

appellantInUk is now determined by the conditonals:
Is detained in 1, 2 or 4 - in Uk
Is categoryId 37 - in UK
is categoryId 38 - not in UK
else if address search is 'GB' - in UK
else - not in UK

and then appealOutOfCountry is set to the opposite of appellantInUk