### PR TITLE
ARIADM-1061 - update countryGovUkOocAdminJ DQ rules and conditional

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
@@ -556,6 +556,7 @@ def build_dq_rules_dependencies(df_final, silver_m1, silver_m2, silver_m3, silve
             .join(detained_df, on="CaseNo", how="left")
             .join(cs46_out31, on="CaseNo", how="left")
             .join(silver_m3_max_casestatus_no_filter, on="CaseNo", how="left")
+            .withColumn("valid_categoryIdList", coalesce(col("valid_categoryIdList"), array()))
     ).dropDuplicates(["CaseNo"])
 
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
@@ -556,7 +556,8 @@ def build_dq_rules_dependencies(df_final, silver_m1, silver_m2, silver_m3, silve
             .join(detained_df, on="CaseNo", how="left")
             .join(cs46_out31, on="CaseNo", how="left")
             .join(silver_m3_max_casestatus_no_filter, on="CaseNo", how="left")
-            .withColumn("valid_categoryIdList", coalesce(col("valid_categoryIdList"), array()))
+            .withColumn("valid_categoryIdList", coalesce(col("valid_categoryIdList"), array()))  # No need to add extra categoryIdList IS NULL rules in the DQ. 
+            .withColumn("lu_HORef", coalesce(col("lu_HORef"), col("HORef"), col("FCONumber")))  # HORef in conditionals can also come from silver_m1, not just the bronze cleansing. The bronze cleansing will be used as priority.
     ).dropDuplicates(["CaseNo"])
 
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/listing_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/listing_dq_rules.py
@@ -56,8 +56,6 @@ class listingDQRules(DQRulesBase):
 
         checks["valid_isEvidenceFromOutsideUkOoc"] = (
             """(
-                (valid_categoryIdList IS NULL AND isEvidenceFromOutsideUkOoc IS NULL)
-                OR
                 (NOT(ARRAY_CONTAINS(valid_categoryIdList, 38)) AND isEvidenceFromOutsideUkOoc IS NULL)
                 OR
                 (ARRAY_CONTAINS(valid_categoryIdList, 38) AND Sponsor_Name IS NOT NULL AND isEvidenceFromOutsideUkOoc <=> 'Yes')
@@ -68,8 +66,6 @@ class listingDQRules(DQRulesBase):
 
         checks["valid_isEvidenceFromOutsideUkInCountry"] = (
             """(
-                (valid_categoryIdList IS NULL AND isEvidenceFromOutsideUkInCountry IS NULL)
-                OR
                 (NOT(ARRAY_CONTAINS(valid_categoryIdList, 37)) AND isEvidenceFromOutsideUkInCountry IS NULL)
                 OR
                 (ARRAY_CONTAINS(valid_categoryIdList, 37) AND Sponsor_Name IS NOT NULL AND isEvidenceFromOutsideUkInCountry <=> 'Yes')

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
@@ -375,21 +375,17 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_caseFlags_name_in_list"] = """(
             (
                 (
-                    (valid_categoryIdList IS NOT NULL)
-                    AND
-                    (EXISTS(valid_categoryIdList, x -> x IN (7, 25)))
+                    EXISTS(valid_categoryIdList, x -> x IN (7, 25))
                 )
                 AND
                 EXISTS(caseFlags.details, x -> x.value.flagComment IS NULL)
             )
             OR
-            (caseFlags.details IS NULL)
+            (caseFlags IS NULL OR caseFlags.details IS NULL)
             OR
             (
                 (
-                    (valid_categoryIdList IS NULL)
-                    OR
-                    (NOT EXISTS(valid_categoryIdList, x -> x IN (7, 25)))
+                    NOT EXISTS(valid_categoryIdList, x -> x IN (7, 25))
                 )
                 AND
                 ARRAY_CONTAINS(TRANSFORM(caseFlags.details, x -> x.value.name), caseFlags.details[0].value.name)
@@ -423,25 +419,28 @@ class paymentPendingDQRules(DQRulesBase):
             )
         )
         """
-        # IF CategoryId not in [7,8,24,25,31,32,41] or valid_categoryIdList is NULL or lu_HOANRef is NULL then caseFlags is NULL
+        # IF CategoryId not in [7,8,24,25,31,32,41] or lu_HOANRef is NULL then caseFlags is NULL
         # IF CategoryId in [7,8,24,25,31,32,41] and lu_HOANRef is not NULL then caseFlags is not NULL
         # IF CategoryId in [7,25] and lu_HOANRef is not NULL, then all flagComment are NULL
         # IF CategoryId in [8,24,31,32,41] and lu_HOANRef is not NULL, then all flagComment are NOT NULL
 
         checks["valid_caseFlags_flagComment_in_list"] = """
         (
-            valid_categoryIdList IS NULL
-            OR lu_HORef IS NULL
-            OR
             (
-                NOT (
-                    array_contains(valid_categoryIdList, 7) OR
-                    array_contains(valid_categoryIdList, 8) OR
-                    array_contains(valid_categoryIdList, 24) OR
-                    array_contains(valid_categoryIdList, 25) OR
-                    array_contains(valid_categoryIdList, 31) OR
-                    array_contains(valid_categoryIdList, 32) OR
-                    array_contains(valid_categoryIdList, 41)
+                (
+                    lu_HORef IS NULL
+                    OR
+                    (
+                        NOT (
+                            array_contains(valid_categoryIdList, 7) OR
+                            array_contains(valid_categoryIdList, 8) OR
+                            array_contains(valid_categoryIdList, 24) OR
+                            array_contains(valid_categoryIdList, 25) OR
+                            array_contains(valid_categoryIdList, 31) OR
+                            array_contains(valid_categoryIdList, 32) OR
+                            array_contains(valid_categoryIdList, 41)
+                        )
+                    )
                 )
                 AND caseFlags IS NULL
             )
@@ -844,7 +843,6 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_appellantHasFixedAddressAdminJ"] = (
             """(
                 (array_contains(valid_categoryIdList, 38) AND appellantHasFixedAddressAdminJ IS NOT NULL AND appellantHasFixedAddressAdminJ IN ('Yes', 'No'))
-                OR (valid_categoryIdList IS NULL AND appellantHasFixedAddressAdminJ IS NULL)
                 OR (NOT array_contains(valid_categoryIdList, 38) AND appellantHasFixedAddressAdminJ IS NULL)
             )"""
         )
@@ -860,7 +858,6 @@ class paymentPendingDQRules(DQRulesBase):
                     addressLine1AdminJ IS NOT NULL
                 )
                 OR (NOT array_contains(valid_categoryIdList, 38) AND addressLine1AdminJ IS NULL)
-                OR (valid_categoryIdList IS NULL AND addressLine1AdminJ IS NULL)
             )"""
         )
 
@@ -875,7 +872,6 @@ class paymentPendingDQRules(DQRulesBase):
                     addressLine2AdminJ IS NOT NULL
                 )
                 OR (NOT array_contains(valid_categoryIdList, 38) AND addressLine2AdminJ IS NULL)
-                OR (valid_categoryIdList IS NULL AND addressLine2AdminJ IS NULL)
             )"""
         )
 
@@ -994,7 +990,7 @@ class paymentPendingDQRules(DQRulesBase):
             """(
                 (
                     NOT array_contains(valid_categoryIdList, 38)
-                    AND  (lu_HORef NOT LIKE '%GWF%' OR HORef NOT LIKE '%GWF%' OR FCONumber NOT LIKE '%GWF%')
+                    AND (lu_HORef NOT LIKE '%GWF%' OR HORef NOT LIKE '%GWF%' OR FCONumber NOT LIKE '%GWF%')
                     AND COALESCE(lu_HORef, HORef, FCONumber) IS NOT NULL
                     AND homeOfficeReferenceNumber IS NOT NULL
                 )

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
@@ -904,7 +904,22 @@ class paymentPendingDQRules(DQRulesBase):
         )
 
         # countryGovUkOocAdminJ: IS NOT NULL when array_contains(valid_categoryIdList, 38); ELSE can be NULL
-        checks["valid_countryGovUkOocAdminJ"] = ("(((array_contains(valid_categoryIdList, 38)) AND (countryGovUkOocAdminJ IS NOT NULL) AND (countryGovUkOocAdminJ IN ('AF', 'AX', 'AL', 'DZ', 'AD', 'AO', 'AI', 'AG', 'AR', 'AM', 'AW', 'AC', 'AU', 'AT', 'AZ', 'BS', 'BH', 'BD', 'BB', 'BY', 'BE', 'BZ', 'BJ', 'BM', 'BT', 'BO', 'BQ', 'BA', 'BW', 'BR', 'IO', 'VG', 'BN', 'BG', 'BF', 'BI', 'KH', 'CM', 'CA', 'IC', 'CV', 'KY', 'CF', 'EA', 'TD', 'CL', 'CN', 'CX', 'CO', 'KM', 'CD', 'CG', 'CK', 'CR', 'HR', 'CU', 'CW', 'CY', 'CZ', 'DK', 'DJ', 'DM', 'DO', 'EC', 'EG', 'SV', 'GQ', 'ER', 'EE', 'ET', 'FK', 'FO', 'FJ', 'FI', 'FR', 'GF', 'PF', 'TF', 'GA', 'GM', 'GE', 'DE', 'GH', 'GI', 'GR', 'GL', 'GD', 'GP', 'GT', 'GN', 'GW', 'GY', 'HT', 'HN', 'HK', 'HU', 'IS', 'IN', 'ID', 'IR', 'IQ', 'IE', 'IL', 'IT', 'CI', 'JM', 'JP', 'JO', 'KZ', 'KE', 'KI', 'KO', 'KW', 'KG', 'LA', 'LV', 'LB', 'LS', 'LR', 'LY', 'LI', 'LT', 'LU', 'MO', 'MK', 'MG', 'YT', 'MW', 'MY', 'MV', 'ML', 'MT', 'MQ', 'MR', 'MU', 'MX', 'MD', 'MN', 'ME', 'MS', 'MA', 'MZ', 'MM', 'NA', 'NR', 'NF', 'NP', 'NL', 'NC', 'NZ', 'NI', 'NE', 'NG', 'NU', 'KP', 'NO', 'OM', 'PK', 'PW', 'PA', 'PG', 'PY', 'PE', 'PH', 'PN', 'PL', 'PT', 'PR', 'QA', 'RE', 'RO', 'RU', 'RW', 'SM', 'ST', 'SA', 'SN', 'RS', 'SC', 'SL', 'SG', 'SK', 'SI', 'SB', 'ZA', 'KR', 'SS', 'ES', 'LK', 'BQ', 'SH', 'KN', 'LC', 'MF', 'VC', 'SD', 'SR', 'SZ', 'SE', 'CH', 'SY', 'TW', 'TJ', 'TZ', 'TH', 'TL', 'TG', 'TK', 'TO', 'TT', 'TN', 'TR', 'TM', 'TC', 'TV', 'UG', 'UA', 'AE', 'GB', 'UY', 'US', 'UZ', 'VU', 'VA', 'VE', 'VN', 'WF', 'EH', 'WS', 'YE', 'ZM', 'ZW', 'PS', 'SO', 'MH', 'MC', 'FM', 'BC', 'ZZ'))) OR (countryGovUkOocAdminJ IS NULL))")
+        checks["valid_countryGovUkOocAdminJ"] = (
+            """(
+                (
+                    (array_contains(valid_categoryIdList, 38))
+                    AND
+                    (countryGovUkOocAdminJ IS NOT NULL)
+                    AND
+                    (countryGovUkOocAdminJ IN ('AF', 'AX', 'AL', 'DZ', 'AD', 'AO', 'AI', 'AG', 'AR', 'AM', 'AW', 'AC', 'AU', 'AT', 'AZ', 'BS', 'BH', 'BD', 'BB', 'BY', 'BE', 'BZ', 'BJ', 'BM', 'BT', 'BO', 'BQ', 'BA', 'BW', 'BR', 'IO', 'VG', 'BN', 'BG', 'BF', 'BI', 'KH', 'CM', 'CA', 'IC', 'CV', 'KY', 'CF', 'EA', 'TD', 'CL', 'CN', 'CX', 'CO', 'KM', 'CD', 'CG', 'CK', 'CR', 'HR', 'CU', 'CW', 'CY', 'CZ', 'DK', 'DJ', 'DM', 'DO', 'EC', 'EG', 'SV', 'GQ', 'ER', 'EE', 'ET', 'FK', 'FO', 'FJ', 'FI', 'FR', 'GF', 'PF', 'TF', 'GA', 'GM', 'GE', 'DE', 'GH', 'GI', 'GR', 'GL', 'GD', 'GP', 'GT', 'GN', 'GW', 'GY', 'HT', 'HN', 'HK', 'HU', 'IS', 'IN', 'ID', 'IR', 'IQ', 'IE', 'IL', 'IT', 'CI', 'JM', 'JP', 'JO', 'KZ', 'KE', 'KI', 'KO', 'KW', 'KG', 'LA', 'LV', 'LB', 'LS', 'LR', 'LY', 'LI', 'LT', 'LU', 'MO', 'MK', 'MG', 'YT', 'MW', 'MY', 'MV', 'ML', 'MT', 'MQ', 'MR', 'MU', 'MX', 'MD', 'MN', 'ME', 'MS', 'MA', 'MZ', 'MM', 'NA', 'NR', 'NF', 'NP', 'NL', 'NC', 'NZ', 'NI', 'NE', 'NG', 'NU', 'KP', 'NO', 'OM', 'PK', 'PW', 'PA', 'PG', 'PY', 'PE', 'PH', 'PN', 'PL', 'PT', 'PR', 'QA', 'RE', 'RO', 'RU', 'RW', 'SM', 'ST', 'SA', 'SN', 'RS', 'SC', 'SL', 'SG', 'SK', 'SI', 'SB', 'ZA', 'KR', 'SS', 'ES', 'LK', 'BQ', 'SH', 'KN', 'LC', 'MF', 'VC', 'SD', 'SR', 'SZ', 'SE', 'CH', 'SY', 'TW', 'TJ', 'TZ', 'TH', 'TL', 'TG', 'TK', 'TO', 'TT', 'TN', 'TR', 'TM', 'TC', 'TV', 'UG', 'UA', 'AE', 'GB', 'UY', 'US', 'UZ', 'VU', 'VA', 'VE', 'VN', 'WF', 'EH', 'WS', 'YE', 'ZM', 'ZW', 'PS', 'SO', 'MH', 'MC', 'FM', 'BC', 'ZZ'))
+                )
+                OR
+                (
+                    (NOT(array_contains(valid_categoryIdList, 38)))
+                    AND
+                    (countryGovUkOocAdminJ IS NULL)
+                )
+            )""")
         ##############################
         # AARIADM-764 (appellantDetails)
         ##############################

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -5,7 +5,6 @@ import pycountry
 import pandas as pd
 import json
 
-from datetime import datetime
 from pyspark.sql import functions as F
 from pyspark.sql.window import Window
 from pyspark.sql.types import StringType
@@ -1447,26 +1446,22 @@ getCountryLRUDF = udf(getCountryLR, StringType())
 ################################################################
 ##########         appellantDetails Function         ###########
 ################################################################
-
-from pyspark.sql.functions import udf, col
-from pyspark.sql.types import StringType
-import pandas as pd
-
-def getCountryApp(country, ukPostcodeAppellant, appellantFullAddress, Appellant_Postcode):
+def getCountryApp(country, ukPostcodeAppellant, appellantFullAddress):
     countryFromAddress = []
     try:
         country = country
         uk_postcode = ukPostcodeAppellant
-        full_address = appellantFullAddress
+        full_address = ', '.join(filter(None, appellantFullAddress)) if appellantFullAddress else ''
 
         if (country is not None and country != 0) or (country is not None and pd.notna(country)):
             countryFromAddress.append(str(country))
             return ', '.join(countryFromAddress)
         else:
-            if uk_postcode is True or uk_postcode == "True":
+            if (uk_postcode is True or uk_postcode == "True"
+                or any(line is not None and line.lower() in ['gb', 'uk', 'united kingdom'] for line in appellantFullAddress)):
                 countryFromAddress.append('GB')
                 return ', '.join(countryFromAddress)
-            if uk_postcode is False or uk_postcode == "False":
+            else:
                 searched_country = getCountryFromAddress(full_address)
                 countryFromAddress.append(searched_country)
                 return ', '.join(countryFromAddress)
@@ -1479,7 +1474,7 @@ getCountryApp_udf = udf(getCountryApp, StringType())
 def derive_country_silver_m2(silver_m2):
     return (
         silver_m2
-        .withColumn("appellantFullAddress", concat_ws(", ",
+        .withColumn("appellantFullAddress", array(
             col("Appellant_Address1"), col("Appellant_Address2"),
             col("Appellant_Address3"), col("Appellant_Address4"),
             col("Appellant_Address5"), col("Appellant_Postcode")
@@ -1488,8 +1483,7 @@ def derive_country_silver_m2(silver_m2):
         .withColumn("dv_countryGovUkOocAdminJ", getCountryApp_udf(
             col("lu_countryGovUkOocAdminJ"),
             col("ukPostcodeAppellant"),
-            col("appellantFullAddress"),
-            col("Appellant_Postcode")
+            col("appellantFullAddress")
         ))
     )
 

--- a/tests/active/paymentPending/appellantDetails_test.py
+++ b/tests/active/paymentPending/appellantDetails_test.py
@@ -56,6 +56,12 @@ def appellantDetails_outputs(spark):
         ("HU/00006/2025", "HU", "2025-04-01", "LR", "1975-03-15", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
         ("HU/00007/2025", "HU", "2025-04-01", "LR", "1975-03-15", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
         ("HU/00008/2025", "HU", "2025-04-01", "LR", "1975-03-15", "211", "ZZ", "Stateless", "refusalOfHumanRights", None, None, None, "HU"),
+        # getCountryApp path tests
+        ("HU/00009/2025", "HU", "2025-04-01", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
+        ("HU/00010/2025", "HU", "2025-04-01", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
+        ("HU/00011/2025", "HU", "2025-04-01", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
+        ("HU/00012/2025", "HU", "2025-04-01", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
+        ("HU/00013/2025", "HU", "2025-04-01", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
     ]
 
     m2_schema = T.StructType([
@@ -140,6 +146,31 @@ def appellantDetails_outputs(spark):
         ("HU/00008/2025", "TestNameX", "TestGivenX", None, None,
         None, None, None, None, None, None,
         None, None, "ZZ", None, 0),
+
+        # getCountryApp: Appellant_Address5 = 'UK' → any() address match → GB
+        ("HU/00009/2025", "TestX", "TestX", None, None,
+        None, None, None, None, "UK", None,
+        None, None, None, None, 0),
+
+        # getCountryApp: valid UK postcode, no Appellant_Address5 → ukPostcodeAppellant = "True" → GB
+        ("HU/00010/2025", "TestX", "TestX", None, None,
+        None, None, None, None, None, "W3 8PF",
+        None, None, None, None, 0),
+
+        # getCountryApp: no postcode, address contains 'Poland' → getCountryFromAddress → PL via bronze lookup
+        ("HU/00011/2025", "TestX", "TestX", None, None,
+        "123 StreetX", None, "Poland", None, None, None,
+        None, None, None, None, 0),
+
+        # getCountryApp: Appellant_Address4 = 'GB' → any() address match → GB
+        ("HU/00012/2025", "TestX", "TestX", None, None,
+        None, None, None, "GB", None, None,
+        None, None, None, None, 0),
+
+        # getCountryApp: Appellant_Address3 = 'United Kingdom' → any() address match → GB
+        ("HU/00013/2025", "TestX", "TestX", None, None,
+        None, None, "United Kingdom", None, None, None,
+        None, None, None, None, 0),
     ]
 
     silver_c_schema = T.StructType([
@@ -158,6 +189,11 @@ def appellantDetails_outputs(spark):
         ("HU/00006/2025", 38),
         ("HU/00007/2025", 38),
         ("HU/00008/2025", 38),
+        ("HU/00009/2025", 38),
+        ("HU/00010/2025", 38),
+        ("HU/00011/2025", 38),
+        ("HU/00012/2025", 38),
+        ("HU/00013/2025", 38),
     ]
 
     bronze_countryFromAddress_schema = T.StructType([
@@ -353,3 +389,28 @@ def test_country_gov_uk_ooc_adminj_new_codes(appellantDetails_outputs):
     assert_equals(appellantDetails_outputs["HU/00006/2025"], countryGovUkOocAdminJ="MH")
     assert_equals(appellantDetails_outputs["HU/00007/2025"], countryGovUkOocAdminJ="MC")
     assert_equals(appellantDetails_outputs["HU/00008/2025"], countryGovUkOocAdminJ="ZZ")
+
+
+def test_country_gov_uk_ooc_adminj_from_appellant_address5(appellantDetails_outputs):
+    """getCountryApp returns GB when Appellant_Address5 is 'UK' — matched via any() check on appellantFullAddress values."""
+    assert_equals(appellantDetails_outputs["HU/00009/2025"], countryGovUkOocAdminJ="GB")
+
+
+def test_country_gov_uk_ooc_adminj_from_uk_postcode(appellantDetails_outputs):
+    """getCountryApp returns GB when Appellant_Postcode is a valid UK postcode and lu_countryGovUkOocAdminJ is None."""
+    assert_equals(appellantDetails_outputs["HU/00010/2025"], countryGovUkOocAdminJ="GB")
+
+
+def test_country_gov_uk_ooc_adminj_from_address_lookup(appellantDetails_outputs):
+    """getCountryApp falls through to getCountryFromAddress when no postcode and no UK Address5; bronze lookup maps the result."""
+    assert_equals(appellantDetails_outputs["HU/00011/2025"], countryGovUkOocAdminJ="PL")
+
+
+def test_country_gov_uk_ooc_adminj_from_gb_in_address(appellantDetails_outputs):
+    """getCountryApp returns GB when an address field is exactly 'GB' — matched via any() check."""
+    assert_equals(appellantDetails_outputs["HU/00012/2025"], countryGovUkOocAdminJ="GB")
+
+
+def test_country_gov_uk_ooc_adminj_from_united_kingdom_in_address(appellantDetails_outputs):
+    """getCountryApp returns GB when an address field is exactly 'United Kingdom' — matched via any() check."""
+    assert_equals(appellantDetails_outputs["HU/00013/2025"], countryGovUkOocAdminJ="GB")

--- a/tests/active/paymentPendingDetained/appellantDetails_test.py
+++ b/tests/active/paymentPendingDetained/appellantDetails_test.py
@@ -36,6 +36,10 @@ def appellantDetails_outputs(spark):
     #   DET/0004:      detained (1) + category 38 (OOC) → detained wins, still "Yes"
     #   DET/0005:      not detained, category 37 (in-UK) → "Yes"
     #   DET/0006:      not detained, category 38 (OOC)  → "No"
+    # Three cases for derive_country_silver_m2 / getCountryApp paths (no category 37/38, not detained):
+    #   DET/0007:      Appellant_Address5='UK', no postcode → dv_countryGovUkOocAdminJ='GB' → appellantInUk="Yes"
+    #   DET/0008:      valid UK postcode, no Address5     → dv_countryGovUkOocAdminJ='GB' → appellantInUk="Yes"
+    #   DET/0009:      address text 'Poland', no postcode → bronze lookup → appellantInUk="No"
     m1_data = [
         ("HU/DET/0001", "HU", "2025-03-07", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
         ("HU/DET/0002", "HU", "2025-03-07", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
@@ -43,6 +47,9 @@ def appellantDetails_outputs(spark):
         ("HU/DET/0004", "HU", "2025-03-07", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
         ("HU/DET/0005", "HU", "2025-03-07", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
         ("HU/DET/0006", "HU", "2025-03-07", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
+        ("HU/DET/0007", "HU", "2025-03-07", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
+        ("HU/DET/0008", "HU", "2025-03-07", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
+        ("HU/DET/0009", "HU", "2025-03-07", "LR", "1980-01-01", "1", "AF", "Afghanistan", "refusalOfHumanRights", None, None, None, "HU"),
     ]
 
     m2_schema = T.StructType([
@@ -71,6 +78,10 @@ def appellantDetails_outputs(spark):
         ("HU/DET/0004", "SmithX", "JohnX", None, None, None, None, None, None, None, None, None, None, None, None, 1),
         ("HU/DET/0005", "SmithX", "JohnX", None, None, "1 High StreetX", None, None, None, None, "SW1A 1AAX", None, None, None, None, 0),
         ("HU/DET/0006", "SmithX", "JohnX", None, None, None, None, None, None, None, None, None, None, None, None, 0),
+        # derive_country_silver_m2 path tests (not detained, no categories)
+        ("HU/DET/0007", "SmithX", "JohnX", None, None, None, None, None, None, "UK", None, None, None, None, None, 0),
+        ("HU/DET/0008", "SmithX", "JohnX", None, None, None, None, None, None, None, "W3 8PF", None, None, None, None, 0),
+        ("HU/DET/0009", "SmithX", "JohnX", None, None, "123 StreetX", None, "Poland", None, None, None, None, None, None, None, 0),
     ]
 
     silver_c_schema = T.StructType([
@@ -113,7 +124,10 @@ def appellantDetails_outputs(spark):
     silver_m1 = spark.createDataFrame(m1_data, m1_schema)
     silver_m2 = spark.createDataFrame(m2_data, m2_schema)
     silver_c = spark.createDataFrame(silver_c_data, silver_c_schema)
-    bronze_countryFromAddress = spark.createDataFrame([], bronze_countryFromAddress_schema)
+    bronze_countryFromAddress_data = [
+        ("Poland", "PL"),
+    ]
+    bronze_countryFromAddress = spark.createDataFrame(bronze_countryFromAddress_data, bronze_countryFromAddress_schema)
     bronze_nationalities = spark.createDataFrame(bronze_nationalities_data, bronze_nationalities_schema)
     bronze_HORef_cleansing = spark.createDataFrame([], bronze_HORef_cleansing_schema)
 
@@ -162,3 +176,21 @@ def test_non_detained_category_38_out_of_country(appellantDetails_outputs):
     """Non-detained with category 38 gets appellantInUk='No' and appealOutOfCountry='Yes'."""
     assert appellantDetails_outputs["HU/DET/0006"]["appellantInUk"] == "No"
     assert appellantDetails_outputs["HU/DET/0006"]["appealOutOfCountry"] == "Yes"
+
+
+def test_appellant_address5_uk_sets_gb(appellantDetails_outputs):
+    """Appellant_Address5='UK' with no lu_countryGovUkOocAdminJ → dv_countryGovUkOocAdminJ='GB' → appellantInUk='Yes'."""
+    assert appellantDetails_outputs["HU/DET/0007"]["appellantInUk"] == "Yes"
+    assert appellantDetails_outputs["HU/DET/0007"]["appealOutOfCountry"] == "No"
+
+
+def test_uk_postcode_sets_gb(appellantDetails_outputs):
+    """Valid UK postcode with no lu_countryGovUkOocAdminJ → dv_countryGovUkOocAdminJ='GB' → appellantInUk='Yes'."""
+    assert appellantDetails_outputs["HU/DET/0008"]["appellantInUk"] == "Yes"
+    assert appellantDetails_outputs["HU/DET/0008"]["appealOutOfCountry"] == "No"
+
+
+def test_address_lookup_non_uk_country(appellantDetails_outputs):
+    """Address containing 'Poland' with no postcode → bronze lookup → non-GB → appellantInUk='No'."""
+    assert appellantDetails_outputs["HU/DET/0009"]["appellantInUk"] == "No"
+    assert appellantDetails_outputs["HU/DET/0009"]["appealOutOfCountry"] == "Yes"


### PR DESCRIPTION
Updated address search functionality to check country address for UK related codes and fail the DQ on missing country when category 38

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [ARIADM-1061](https://tools.hmcts.net/jira/browse/ARIADM-1061)

### Change description

countryGovUkOocAdminJ DQ rules updated to fail when category is 38 but countryGovUkOocAdminJ is NULL.
countryGovUkOocAdminJ DQ rule updated so that when category is not 38, it is NULL (OMIT per mapping).
Added checking appellant_address5 field for GB, UK, or United Kingdom exact values to determine the country to be added.