### PR TITLE
Updated logic to only do the country search on AppellantCountryId = 0

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1446,17 +1446,17 @@ getCountryLRUDF = udf(getCountryLR, StringType())
 ################################################################
 ##########         appellantDetails Function         ###########
 ################################################################
-def getCountryApp(country, ukPostcodeAppellant, appellantFullAddress):
+def getCountryApp(countryId, country, ukPostcodeAppellant, appellantFullAddress):
     countryFromAddress = []
     try:
         country = country
         uk_postcode = ukPostcodeAppellant
         full_address = ', '.join(filter(None, appellantFullAddress)) if appellantFullAddress else ''
 
-        if (country is not None and country != 0) or (country is not None and pd.notna(country)):
+        if (country is not None and countryId != 0) or (country is not None and pd.notna(country)):
             countryFromAddress.append(str(country))
             return ', '.join(countryFromAddress)
-        else:
+        elif countryId == 0:  # Only do the country search when countryId = 0
             if (uk_postcode is True or uk_postcode == "True"
                 or any(line is not None and line.lower() in ['gb', 'uk', 'united kingdom'] for line in appellantFullAddress)):
                 countryFromAddress.append('GB')
@@ -1465,7 +1465,8 @@ def getCountryApp(country, ukPostcodeAppellant, appellantFullAddress):
                 searched_country = getCountryFromAddress(full_address)
                 countryFromAddress.append(searched_country)
                 return ', '.join(countryFromAddress)
-        return ', '.join(countryFromAddress)
+        else:
+            return "NO MAPPING REQUIRED"  # AppellantCountryId is null or not in the postal lookup.
     except Exception:
         return None
 
@@ -1481,6 +1482,7 @@ def derive_country_silver_m2(silver_m2):
         ))
         .withColumn("ukPostcodeAppellant", getUkPostcodeUDF(col("Appellant_Postcode")))
         .withColumn("dv_countryGovUkOocAdminJ", getCountryApp_udf(
+            col("AppellantCountryId"),
             col("lu_countryGovUkOocAdminJ"),
             col("ukPostcodeAppellant"),
             col("appellantFullAddress")

--- a/tests/active/paymentPending/appellantDetails_test.py
+++ b/tests/active/paymentPending/appellantDetails_test.py
@@ -126,7 +126,7 @@ def appellantDetails_outputs(spark):
 
         ("HU/00004/2025", "WilliamsX", "SarahX", None, None,
         None, None, None, None, None, "SW1A 1AA",
-        None, None, None, None, 0),
+        0, None, None, None, 0),
 
         ("HU/00005/2025", "WilliamsX", "SarahX", None, None,
         None, None, None, None, None, None,
@@ -150,27 +150,27 @@ def appellantDetails_outputs(spark):
         # getCountryApp: Appellant_Address5 = 'UK' → any() address match → GB
         ("HU/00009/2025", "TestX", "TestX", None, None,
         None, None, None, None, "UK", None,
-        None, None, None, None, 0),
+        0, None, None, None, 0),
 
         # getCountryApp: valid UK postcode, no Appellant_Address5 → ukPostcodeAppellant = "True" → GB
         ("HU/00010/2025", "TestX", "TestX", None, None,
         None, None, None, None, None, "W3 8PF",
-        None, None, None, None, 0),
+        0, None, None, None, 0),
 
         # getCountryApp: no postcode, address contains 'Poland' → getCountryFromAddress → PL via bronze lookup
         ("HU/00011/2025", "TestX", "TestX", None, None,
         "123 StreetX", None, "Poland", None, None, None,
-        None, None, None, None, 0),
+        0, None, None, None, 0),
 
         # getCountryApp: Appellant_Address4 = 'GB' → any() address match → GB
         ("HU/00012/2025", "TestX", "TestX", None, None,
         None, None, None, "GB", None, None,
-        None, None, None, None, 0),
+        0, None, None, None, 0),
 
         # getCountryApp: Appellant_Address3 = 'United Kingdom' → any() address match → GB
         ("HU/00013/2025", "TestX", "TestX", None, None,
         None, None, "United Kingdom", None, None, None,
-        None, None, None, None, 0),
+        0, None, None, None, 0),
     ]
 
     silver_c_schema = T.StructType([

--- a/tests/active/paymentPendingDetained/appellantDetails_test.py
+++ b/tests/active/paymentPendingDetained/appellantDetails_test.py
@@ -79,9 +79,9 @@ def appellantDetails_outputs(spark):
         ("HU/DET/0005", "SmithX", "JohnX", None, None, "1 High StreetX", None, None, None, None, "SW1A 1AAX", None, None, None, None, 0),
         ("HU/DET/0006", "SmithX", "JohnX", None, None, None, None, None, None, None, None, None, None, None, None, 0),
         # derive_country_silver_m2 path tests (not detained, no categories)
-        ("HU/DET/0007", "SmithX", "JohnX", None, None, None, None, None, None, "UK", None, None, None, None, None, 0),
-        ("HU/DET/0008", "SmithX", "JohnX", None, None, None, None, None, None, None, "W3 8PF", None, None, None, None, 0),
-        ("HU/DET/0009", "SmithX", "JohnX", None, None, "123 StreetX", None, "Poland", None, None, None, None, None, None, None, 0),
+        ("HU/DET/0007", "SmithX", "JohnX", None, None, None, None, None, None, "UK", None, 0, None, None, None, 0),
+        ("HU/DET/0008", "SmithX", "JohnX", None, None, None, None, None, None, None, "W3 8PF", 0, None, None, None, 0),
+        ("HU/DET/0009", "SmithX", "JohnX", None, None, "123 StreetX", None, "Poland", None, None, None, 0, None, None, None, 0),
     ]
 
     silver_c_schema = T.StructType([


### PR DESCRIPTION
Based on comment on ARIADM-1061

Similar to on [ARIADM-2218](https://tools.hmcts.net/jira/browse/ARIADM-2218) NO MAPPING REQURIED should fail the DLT expectation.
Where there isn't a country recorded (AppellantCountryId = 0 ) we use the Address/postcode to derive the country. 

201,203 207,39,151,210 - none of these values exist in the active segment in ARIA PROD hence why we don't have a mapping for them. So for these they should all be NO MAPPING REQUIRED and as such fail the DLT Expectation.

If a country cannot be detected (and returns a blank string) - this is correct to fail the DLT Exp.