### PR TITLE
ARIADM-2262 SponsorDetails Line Separators

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -2605,7 +2605,7 @@ def sponsorDetails(silver_m1, silver_c):
         when(
             name_condition,
             concat_ws(
-                "\r\n",
+                "\\r\\n",
                 col("Sponsor_Address1"),
                 col("Sponsor_Address2"),
                 col("Sponsor_Address3"),

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
@@ -514,7 +514,7 @@ def sponsorDetails(silver_m1, silver_c):
         when(
             name_condition,
             concat_ws(
-                "\r\n",
+                "\\r\\n",
                 col("Sponsor_Address1"),
                 col("Sponsor_Address2"),
                 col("Sponsor_Address3"),

--- a/tests/active/paymentPending/sponsorDetails_test.py
+++ b/tests/active/paymentPending/sponsorDetails_test.py
@@ -222,10 +222,10 @@ def test_sponsorAddressForDisplay(spark,sponsorDetails_outputs):
     results = sponsorDetails_outputs
 
     assert results["EA/00490/2025"]["sponsorAddressForDisplay"] is None
-    assert results["EA/00072/2025"]["sponsorAddressForDisplay"] == '873 Hurst Parkways Suite 226X\r\nOwens StravenueX\r\nL7T 6AE'
-    assert results["HU/00447/2025"]["sponsorAddressForDisplay"] == '64644 Michael Junction Suite 48X\r\nKathryn MeadowX\r\nG30 7NJ'
+    assert results["EA/00072/2025"]["sponsorAddressForDisplay"] == '873 Hurst Parkways Suite 226X\\r\\nOwens StravenueX\\r\\nL7T 6AE'
+    assert results["HU/00447/2025"]["sponsorAddressForDisplay"] == '64644 Michael Junction Suite 48X\\r\\nKathryn MeadowX\\r\\nG30 7NJ'
     assert results["EA/00061/2025"]["sponsorAddressForDisplay"] == ''
-    assert results["HU/00574/2023"]["sponsorAddressForDisplay"] == '358 Carter Corners Suite 044X\r\nWells FordX\r\nUB4B 0LY'
+    assert results["HU/00574/2023"]["sponsorAddressForDisplay"] == '358 Carter Corners Suite 044X\\r\\nWells FordX\\r\\nUB4B 0LY'
 
 
 


### PR DESCRIPTION
Escape return newline for sponsorAddressForDisplay as string should be on one line

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [ARIADM-2262](https://tools.hmcts.net/jira/browse/ARIADM-2262)
