### PR TITLE
Fixed DQ rules for ftpaApplicationDeadline

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
@@ -26,15 +26,13 @@ class decidedADQRules(DQRulesBase):
                     )
                     OR
                     (
-                        CaseStatus_SD NOT IN (37,38,26)
-                        AND Outcome_SD NOT IN (1,2)
+                        (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
                         AND element_at(actualCaseHearingLength, 'hours') IS NULL
                         AND element_at(actualCaseHearingLength, 'minutes') IS NULL
                     )
                     OR
                     (
-                        CaseStatus_SD IS NOT NULL
-                        AND Outcome_SD IS NULL
+                        (CaseStatus_SD IS NOT NULL OR Outcome_SD IS NULL)
                         AND element_at(actualCaseHearingLength, 'hours') IS NULL
                         AND element_at(actualCaseHearingLength, 'minutes') IS NULL
                     )
@@ -62,19 +60,43 @@ class decidedADQRules(DQRulesBase):
 
         checks["valid_sendDecisionsAndReasonsDate"] = """
         (
-            CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-            AND 
-            to_date(
-                to_timestamp(DecisionDate, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX')
-            ) = to_date(trim(sendDecisionsAndReasonsDate), 'yyyy-MM-dd')
+            (
+                CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
+                AND 
+                to_date(
+                    to_timestamp(DecisionDate, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX')
+                ) = to_date(trim(sendDecisionsAndReasonsDate), 'yyyy-MM-dd')
+            )
+            OR
+            (
+                (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
+                AND appealDate IS NULL
+            )
+            OR
+            (
+                (CaseStatus_SD IS NULL OR Outcome_SD IS NULL)
+                AND appealDate IS NULL
+            )
         )
         """
 
         checks["valid_appealDate"] = """
         (
-            CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-            AND 
-            to_date(DecisionDate, 'yyyy-MM-dd') = to_date(appealDate, 'yyyy-MM-dd')
+            (
+                CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
+                AND 
+                to_date(DecisionDate, 'yyyy-MM-dd') = to_date(appealDate, 'yyyy-MM-dd')
+            )
+            OR
+            (
+                (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
+                AND appealDate IS NULL
+            )
+            OR
+            (
+                (CaseStatus_SD IS NULL OR Outcome_SD IS NULL)
+                AND appealDate IS NULL
+            )
         )
         """
 
@@ -82,25 +104,48 @@ class decidedADQRules(DQRulesBase):
 
         checks["valid_appealDecision"] = """
         (
-            
-            CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-            AND 
-            CASE
-                WHEN Outcome_SD = 1 THEN (appealDecision = 'Allowed')
-                WHEN Outcome_SD = 2 THEN (appealDecision = 'Dismissed')
-            END
+            (
+                CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
+                AND 
+                CASE
+                    WHEN Outcome_SD = 1 THEN (appealDecision = 'Allowed')
+                    WHEN Outcome_SD = 2 THEN (appealDecision = 'Dismissed')
+                END
+            )
+            OR
+            (
+                (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
+                AND appealDecision IS NULL
+            )
+            OR
+            (
+                (CaseStatus_SD IS NULL OR Outcome_SD IS NULL)
+                AND appealDecision IS NULL
+            )
         )
         """
 
         checks["valid_isDecisionAllowed"] = """
         (
-            CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-            AND 
-            CASE
-                WHEN Outcome_SD = 1 THEN (isDecisionAllowed = 'allowed')
-                WHEN Outcome_SD = 2 THEN (isDecisionAllowed = 'dismissed')
-                ELSE (isDecisionAllowed IS NULL)
-            END
+            (
+                CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
+                AND 
+                CASE
+                    WHEN Outcome_SD = 1 THEN (isDecisionAllowed = 'allowed')
+                    WHEN Outcome_SD = 2 THEN (isDecisionAllowed = 'dismissed')
+                    ELSE (isDecisionAllowed IS NULL)
+                END
+            )
+            OR
+            (
+                (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
+                AND isDecisionAllowed IS NULL
+            )
+            OR
+            (
+                (CaseStatus_SD IS NULL OR Outcome_SD IS NULL)
+                AND isDecisionAllowed IS NULL
+            )
         )
         """
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
@@ -15,15 +15,37 @@ class decidedADQRules(DQRulesBase):
     def get_checks_hearing_actuals(self, checks={}):
 
         checks["valid_actualCaseHearingLength"] = ("""
-        
-        (
-            CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-            AND element_at(actualCaseHearingLength, 'hours') =
-                CAST(FLOOR(CAST(HearingDuration AS INT) / 60) AS STRING)
-            AND element_at(actualCaseHearingLength, 'minutes') =
-                CAST(CAST(HearingDuration AS INT) % 60 AS STRING)
-            )
-        """)
+                (
+                    (
+                        CaseStatus_SD IN (37,38,26)
+                        AND Outcome_SD IN (1,2)
+                        AND element_at(actualCaseHearingLength, 'hours') =
+                            CAST(FLOOR(CAST(HearingDuration AS INT) / 60) AS STRING)
+                        AND element_at(actualCaseHearingLength, 'minutes') =
+                            CAST(CAST(HearingDuration AS INT) % 60 AS STRING)
+                    )
+                    OR
+                    (
+                        CaseStatus_SD NOT IN (37,38,26)
+                        AND Outcome_SD NOT IN (1,2)
+                        AND element_at(actualCaseHearingLength, 'hours') IS NULL
+                        AND element_at(actualCaseHearingLength, 'minutes') IS NULL
+                    )
+                    OR
+                    (
+                        CaseStatus_SD IS NOT NULL
+                        AND Outcome_SD IS NULL
+                        AND element_at(actualCaseHearingLength, 'hours') IS NULL
+                        AND element_at(actualCaseHearingLength, 'minutes') IS NULL
+                    )
+                    OR
+                    (
+                        hearingDuration IS NULL
+                        AND element_at(actualCaseHearingLength, 'hours') IS NULL
+                        AND element_at(actualCaseHearingLength, 'minutes') IS NULL
+                    )
+                )
+                """)
 
         checks["valid_attendingJudge"] = (
             """

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
@@ -97,25 +97,6 @@ class decidedADQRules(DQRulesBase):
         return checks
 
     def get_checks_ftpa(self, checks={}):
-
-        # checks["valid_ftpaApplicationDeadline"] = """
-        #     (
-        #         (DecisionDate IS NULL AND ftpaApplicationDeadline IS NULL)
-        #         OR
-        #         CASE
-        #             WHEN Outcome_SD IN (1, 2) AND CaseStatus_SD IN (37, 38, 26) AND CategoryId_37 = 37 THEN
-        #                 date_add(DecisionDate, 14) = to_date(ftpaApplicationDeadline)
-        #             WHEN Outcome_SD IN (1, 2) AND CaseStatus_SD IN (37, 38, 26) AND CategoryId_37 = 38 THEN
-        #                 date_add(DecisionDate, 28) = to_date(ftpaApplicationDeadline)
-        #             ELSE
-        #                 date_add(DecisionDate, 0) = to_date(ftpaApplicationDeadline)
-        #         END
-        #     )
-        #     """
-
-        # return checks
-    
-        
         
         checks["valid_ftpaApplicationDeadline"] = """
         (
@@ -125,18 +106,25 @@ class decidedADQRules(DQRulesBase):
                         AND CaseStatus_SD IN (37, 38, 26)
                         AND CategoryId = 37
                     THEN
-                        to_date(ftpaApplicationDeadline) = date_add(DecisionDate, 14)
+                        to_date(ftpaApplicationDeadline) = to_date(date_add(DecisionDate, 14))
 
                     WHEN Outcome_SD IN (1, 2)
                         AND CaseStatus_SD IN (37, 38, 26)
                         AND CategoryId = 38
                     THEN
-                        to_date(ftpaApplicationDeadline) = date_add(DecisionDate, 28)
+                        to_date(ftpaApplicationDeadline) = to_date(date_add(DecisionDate, 28))
                 END
+            )
+            OR
+            (
+                (
+                    (Outcome_SD IS NULL OR Outcome_SD NOT IN (1,2))
+                    OR (CaseStatus_SD IS NULL OR CaseStatus_SD NOT IN (37,38,26))
+                    OR (CategoryId IS NULL OR CategoryId NOT IN (37,38))
+                )
+                AND ftpaApplicationDeadline IS NULL
             )
         )
         """
         return checks
-
-
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
@@ -259,32 +259,62 @@ class prepareForHearingDQRules(DQRulesBase):
 
         checks["valid_listCaseHearingLength"] = ("""
         (
-            CAST(roundedTimeEstimate AS STRING) <=> CAST(listCaseHearingLength AS STRING) 
-            AND CaseStatus_dec IN (37,38)
-            AND CAST(roundedTimeEstimate AS INT) IN (30, 60, 90, 120, 150, 180,210, 240, 270, 300, 330, 360)
+            (
+                CAST(roundedTimeEstimate AS STRING) <=> CAST(listCaseHearingLength AS STRING) 
+                AND CaseStatus_dec IN (37,38)
+                AND CAST(roundedTimeEstimate AS INT) IN (30, 60, 90, 120, 150, 180,210, 240, 270, 300, 330, 360)
+            )
+            OR
+            (
+                (CaseStatus_dec NOT IN (37,38) OR CaseStatus_dec IS NULL) AND roundedTimeEstimate IS NULL
+            )
         )
         """)
 
         checks["valid_listCaseHearingDate"] = (
             """
             (
-                listCaseHearingDate <=>
-                    CONCAT(date_format(CAST(HearingDate AS timestamp), 'yyyy-MM-dd'),'T',
-                        CASE
-                        WHEN StartTime IS NULL THEN '00:00:00.000'
-                        ELSE date_format(CAST(StartTime AS timestamp), 'HH:mm:ss.SSS')
-                        END)
-                    AND CaseStatus_dec IN (37,38)
+                (
+                    listCaseHearingDate <=>
+                        CONCAT(date_format(CAST(HearingDate AS timestamp), 'yyyy-MM-dd'),'T',
+                            CASE
+                            WHEN StartTime IS NULL THEN '00:00:00.000'
+                            ELSE date_format(CAST(StartTime AS timestamp), 'HH:mm:ss.SSS')
+                            END)
+                        AND CaseStatus_dec IN (37,38)
+                )
+                OR
+                (
+                    (CaseStatus_dec NOT IN (37,38) OR CaseStatus_dec IS NULL) AND roundedTimeEstimate IS NULL
+                )
             )
             """)
 
         checks["valid_listCaseHearingCentre"] = (
-            "(listCaseHearingCentre <=> bronze_listCaseHearingCentre AND CaseStatus_dec IN (37,38) )" 
-        )
+            """
+            (
+                (
+                    listCaseHearingCentre <=> bronze_listCaseHearingCentre AND CaseStatus_dec IN (37,38) 
+                )
+                OR
+                (
+                    (CaseStatus_dec NOT IN (37,38) OR CaseStatus_dec IS NULL) AND listCaseHearingCentre IS NULL
+                )
+            )
+        """)
 
         checks["valid_listCaseHearingCentreAddress"] = (
-            "(listCaseHearingCentreAddress <=> bronze_listCaseHearingCentreAddress AND CaseStatus_dec IN (37,38))"
-        )
+            """
+            (
+                (
+                    listCaseHearingCentreAddress <=> bronze_listCaseHearingCentreAddress AND CaseStatus_dec IN (37,38)
+                )
+                OR
+                (
+                    (CaseStatus_dec NOT IN (37,38) OR CaseStatus_dec IS NULL) AND listCaseHearingCentreAddress IS NULL
+                )
+            )
+            """)
 
         return checks
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
@@ -15,9 +15,22 @@ class prepareForHearingDQRules(DQRulesBase):
 
         checks["valid_isAppealSuitableToFloat"] = (
             """(
-                (listTypeId = 5 AND isAppealSuitableToFloat = 'Yes')
-                OR
-                (listTypeId != 5 AND isAppealSuitableToFloat = 'No')
+                CaseStatus_dec IN (37,38)
+                AND
+                (
+                    (listTypeId = 5 AND isAppealSuitableToFloat = 'Yes')
+                    OR
+                    ((listTypeId != 5 OR listTypeId IS NULL) AND isAppealSuitableToFloat = 'No')
+                )
+            )
+            OR
+            (
+                CaseStatus_dec NOT IN (37,38)
+                AND isAppealSuitableToFloat IS NULL
+            )
+            OR
+            (
+                CaseStatus_dec IS NULL AND isAppealSuitableToFloat IS NULL
             )"""
         )
 


### PR DESCRIPTION
Missing NULL checks and ensuring DecisionDate is in date format, instead of timestamp.
