### PR TITLE
Fixed edge case for final decidedB failing DQ

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/decided_b.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/decided_b.py
@@ -16,7 +16,7 @@ from pyspark.sql.functions import (
     col, when, lit, array, struct, collect_list, 
     max as spark_max, date_format, row_number, expr, regexp_replace,
     size, udf, coalesce, concat_ws, concat, trim, year, split, datediff,
-    collect_set, current_timestamp,transform, first, array_contains,rank,create_map, map_from_entries, map_from_arrays
+    collect_set, current_timestamp,transform, first, array_contains,rank,create_map, map_from_entries, map_from_arrays, nullif
 )
 
 
@@ -92,7 +92,7 @@ def setAside(silver_m1, silver_m3, silver_m6):
     silver_m6_conditional = silver_m6.withColumn("formatted_judge",when(col("Required") == False, formatted_judge).otherwise(None))
 
     # Step 3: Group by case and join using newline separator
-    judges_per_case_single = (silver_m6_conditional.groupBy("CaseNo").agg(concat_ws("\n", collect_list("formatted_judge")).alias("Judges")))
+    judges_per_case_single = (silver_m6_conditional.groupBy("CaseNo").agg(nullif(concat_ws("\n", collect_list("formatted_judge")), lit("")).alias("Judges")))
 
 
     # Window: highest StatusId per CaseNo
@@ -119,10 +119,6 @@ def setAside(silver_m1, silver_m3, silver_m6):
             .join(silver_m3_max_casestatus.alias("casemax"), on="CaseNo", how="left")
     )
 
-
-
-
-    
     # Build remittal content
     setaside_df = (
         silver_m1.alias("m1").join(silver_m3_max_statusid.alias("m3"), on="CaseNo", how="left")

--- a/tests/active/decided_b/setAside_test.py
+++ b/tests/active/decided_b/setAside_test.py
@@ -120,8 +120,8 @@ def test_judgesNamesToExclude(spark,setAside_outputs):
     results = setAside_outputs
 
     assert results["CASE005"]["judgesNamesToExclude"] == 'Black, Tim (Sir)'
-    assert results["CASE006"]["judgesNamesToExclude"] == ''
-    assert results["CASE007"]["judgesNamesToExclude"] == ''
+    assert results["CASE006"]["judgesNamesToExclude"] == None
+    assert results["CASE007"]["judgesNamesToExclude"] == None
     assert results["CASE010"]["judgesNamesToExclude"] == 'pearn, Leo (Mr)'
     assert results["CASE011"]["judgesNamesToExclude"] == 'Finney, Alex (Prof)'
 


### PR DESCRIPTION
the concat_ws evaluates nulls / no values provided to an empty string. I have added a nullif check to determine if the step that should  produce a null is producing an empty string. if the judges_per_case_single variable is producing an empty string, then convert to null value.
