### PR TITLE
Fix ftpaApplicationDeadline across states

### DIFF
--- a/ARIA_DABs/resources/pipelines/PL_ARIADM_ACTIVE_FTPA_DECIDED_GOLD.yml
+++ b/ARIA_DABs/resources/pipelines/PL_ARIADM_ACTIVE_FTPA_DECIDED_GOLD.yml
@@ -7,8 +7,8 @@ resources:
 
       clusters:
         - label: default
-          node_type_id: Standard_D8ads_v5
-          driver_node_type_id: Standard_D8ads_v5
+          node_type_id: Standard_D16ads_v5
+          driver_node_type_id: Standard_D16ads_v5
           autoscale:
             min_workers: 1
             max_workers: 8

--- a/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_A_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_A_JSON.ipynb
@@ -9,9 +9,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
+     "finishTime": 1782399793245,
      "inputWidgets": {},
      "nuid": "65cb672e-fad4-41c9-955b-9e447b8ff7f6",
      "showTitle": true,
+     "startTime": 1782399787242,
+     "submitTime": 1782399787029,
      "tableResultSettingsMap": {},
      "title": "Create Python Wheel"
     }
@@ -71,9 +74,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
+     "finishTime": 1782399794523,
      "inputWidgets": {},
      "nuid": "8b74449b-e058-46d3-a261-7cb376b3c009",
      "showTitle": false,
+     "startTime": 1782399793259,
+     "submitTime": 1782399787051,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -101,9 +107,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
+     "finishTime": 1782399794722,
      "inputWidgets": {},
      "nuid": "7831545c-1e19-4244-ab14-25869bbd78f7",
      "showTitle": true,
+     "startTime": 1782399794531,
+     "submitTime": 1782399787055,
      "tableResultSettingsMap": {},
      "title": "Import packages"
     }
@@ -126,9 +135,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
+     "finishTime": 1782399795624,
      "inputWidgets": {},
      "nuid": "e251edd4-ffe0-47d2-9c90-2add21a1af59",
      "showTitle": true,
+     "startTime": 1782399794731,
+     "submitTime": 1782399787059,
      "tableResultSettingsMap": {},
      "title": "Assign configs"
     }
@@ -155,9 +167,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
+     "finishTime": 1782399796225,
      "inputWidgets": {},
      "nuid": "36f0c0bd-2026-4b2c-8800-f4732e142615",
      "showTitle": true,
+     "startTime": 1782399795636,
+     "submitTime": 1782399787064,
      "tableResultSettingsMap": {},
      "title": "Assign OAuth"
     }
@@ -223,9 +238,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
+     "finishTime": 1782399796525,
      "inputWidgets": {},
      "nuid": "e169fc23-7079-4102-8017-e009060ec361",
      "showTitle": true,
+     "startTime": 1782399796235,
+     "submitTime": 1782399787068,
      "tableResultSettingsMap": {},
      "title": "Assign Paths"
     }
@@ -266,9 +284,12 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
+     "finishTime": 1782399798326,
      "inputWidgets": {},
      "nuid": "6d30465e-ae52-4a05-9eab-bba6e0964456",
      "showTitle": true,
+     "startTime": 1782399796535,
+     "submitTime": 1782399787072,
      "tableResultSettingsMap": {},
      "title": "Read in tables"
     }
@@ -621,16 +642,26 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
+     "finishTime": 1782403708246,
      "inputWidgets": {},
      "nuid": "5c6309c9-7259-4cfc-9365-7d8410be94ad",
      "showTitle": true,
-     "tableResultSettingsMap": {},
+     "startTime": 1782403705955,
+     "submitTime": 1782403705918,
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1782375215752}",
+       "filterBlob": "{\"version\":1,\"filterGroups\":[{\"enabled\":true,\"op\":\"OR\",\"filterGroupId\":\"fg_53163dd5\",\"filters\":[{\"filterId\":\"f_cfd3e1c3\",\"columnId\":\"CaseNo\",\"enabled\":true,\"dataType\":\"string\",\"filterType\":\"oneof\",\"filterValue\":\"\",\"filterValues\":[\"EA/00331/2025\",\"IA/01578/2022\",\"IA/01900/2020\",\"IA/02619/2022\",\"IA/03100/2021\",\"IA/03434/2021\",\"IA/09895/2022\",\"LE/01736/2025\",\"LH/06091/2023\"],\"filterConfig\":{\"caseSensitive\":true}}],\"local\":false,\"updatedAt\":1782401354626},{\"enabled\":true,\"filterGroupId\":\"fg_c06f2158\",\"op\":\"OR\",\"filters\":[{\"filterId\":\"f_a9de5409\",\"enabled\":true,\"columnId\":\"CaseNo\",\"dataType\":\"string\",\"filterType\":\"oneof\",\"filterValues\":[],\"filterConfig\":{\"caseSensitive\":true}}],\"local\":false,\"updatedAt\":1782401289948},{\"enabled\":true,\"filterGroupId\":\"fg_f4f84dc6\",\"op\":\"OR\",\"filters\":[{\"filterId\":\"f_ab522c0\",\"enabled\":true,\"columnId\":\"CaseNo\",\"dataType\":\"string\",\"filterType\":\"oneof\"}],\"local\":false,\"updatedAt\":1782401294208}],\"syncTimestamp\":1782401354626}",
+       "queryPlanFiltersBlob": "[{\"kind\":\"call\",\"function\":\"and\",\"args\":[{\"kind\":\"call\",\"function\":\"or\",\"args\":[{\"kind\":\"call\",\"function\":\"in\",\"args\":[{\"kind\":\"identifier\",\"identifier\":\"CaseNo\"},{\"kind\":\"literal\",\"value\":\"EA/00331/2025\",\"type\":\"string\"},{\"kind\":\"literal\",\"value\":\"IA/01578/2022\",\"type\":\"string\"},{\"kind\":\"literal\",\"value\":\"IA/01900/2020\",\"type\":\"string\"},{\"kind\":\"literal\",\"value\":\"IA/02619/2022\",\"type\":\"string\"},{\"kind\":\"literal\",\"value\":\"IA/03100/2021\",\"type\":\"string\"},{\"kind\":\"literal\",\"value\":\"IA/03434/2021\",\"type\":\"string\"},{\"kind\":\"literal\",\"value\":\"IA/09895/2022\",\"type\":\"string\"},{\"kind\":\"literal\",\"value\":\"LE/01736/2025\",\"type\":\"string\"},{\"kind\":\"literal\",\"value\":\"LH/06091/2023\",\"type\":\"string\"}]}]}]}]",
+       "tableResultIndex": 0
+      }
+     },
      "title": "Function: ftpa"
     }
    },
    "outputs": [],
    "source": [
-    "df,df_audit = DA.ftpa(silver_m1, silver_m3, silver_c)\n",
+    "df, df_audit = DA.ftpa(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "# display(df)"
    ]
   },
@@ -796,7 +827,7 @@
     "    hearingRequirements_df, hearingRequirements_df_audit = L.hearingRequirements(silver_m1, silver_m3, silver_c, bronze_interpreter_languages)\n",
     "    substantiveDecision_df, substantiveDecision_df_audit = DA.substantiveDecision(silver_m1,silver_m3)\n",
     "    hearingActuals_df, hearingActuals_df_audit = DA.hearingActuals(silver_m1,silver_m3)\n",
-    "    ftpa_df, ftpa_df_audit = DA.ftpa(silver_m1, silver_m3,silver_c)\n",
+    "    ftpa_df, ftpa_df_audit = DA.ftpa(silver_m1, silver_m2, silver_m3,silver_c)\n",
     "    detainedState_df, detainedState_df_audit = PPD.detained(silver_m1,silver_m2,bronze_detention_centres)\n",
     "\n",
     "    silver_segmentation_df = silver_segmentation\n",
@@ -1304,7 +1335,7 @@
    "language": "python",
    "notebookMetadata": {
     "mostRecentlyExecutedCommandWithImplicitDF": {
-     "commandId": 6622414321274158,
+     "commandId": 4813493272251552,
      "dataframes": [
       "_sqldf"
      ]

--- a/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_B_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_B_JSON.ipynb
@@ -632,7 +632,7 @@
    },
    "outputs": [],
    "source": [
-    "df,df_audit = DB.ftpa(silver_m1,silver_m3, silver_c)\n",
+    "df,df_audit = DB.ftpa(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "# display(df)"
    ]
   },
@@ -820,7 +820,7 @@
     "    hearingRequirements_df, hearingRequirements_df_audit = L.hearingRequirements(silver_m1, silver_m3, silver_c, bronze_interpreter_languages)\n",
     "    substantiveDecision_df, substantiveDecision_df_audit = DA.substantiveDecision(silver_m1,silver_m3)\n",
     "    hearingActuals_df, hearingActuals_df_audit = DA.hearingActuals(silver_m1,silver_m3)\n",
-    "    ftpa_df, ftpa_df_audit = DB.ftpa(silver_m1,silver_m3,silver_c)\n",
+    "    ftpa_df, ftpa_df_audit = DB.ftpa(silver_m1, silver_m2, silver_m3,silver_c)\n",
     "    setAside_df, setAside_df_audit = DB.setAside(silver_m1,silver_m3,silver_m6)\n",
     "    detainedState_df, detainedState_df_audit = PPD.detained(silver_m1,silver_m2,bronze_detention_centres)\n",
     "\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_ENDED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_ENDED_JSON.ipynb
@@ -681,7 +681,7 @@
    },
    "outputs": [],
    "source": [
-    "df,df_audit = E.ftpa(silver_m1, silver_m3, silver_c)\n",
+    "df,df_audit = E.ftpa(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "# display(df)"
    ]
   },
@@ -876,7 +876,7 @@
     "    hearingRequirements_df, hearingRequirements_df_audit = E.hearingRequirements(silver_m1, silver_m3, silver_c, bronze_interpreter_languages)\n",
     "    substantiveDecision_df, substantiveDecision_df_audit = E.substantiveDecision(silver_m1,silver_m3)\n",
     "    hearingActuals_df, hearingActuals_df_audit = E.hearingActuals(silver_m1,silver_m3)\n",
-    "    ftpa_df, ftpa_df_audit = E.ftpa(silver_m1,silver_m3,silver_c)\n",
+    "    ftpa_df, ftpa_df_audit = E.ftpa(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    ended_df, ended_df_audit = E.ended(silver_m1,silver_m3,bronze_ended_states)\n",
     "    detainedState_df, detainedState_df_audit = PPD.detained(silver_m1,silver_m2,bronze_detention_centres)\n",
     "\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_FTPA_DECIDED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_FTPA_DECIDED_JSON.ipynb
@@ -626,7 +626,7 @@
    },
    "outputs": [],
    "source": [
-    "ftpaDec_df, ftpa_audit = FTD.ftpa(silver_m1, silver_m3, silver_c)\n",
+    "ftpaDec_df, ftpa_audit = FTD.ftpa(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "# display(ftpaDec_df)"
    ]
   },
@@ -792,7 +792,7 @@
     "    hearingRequirements_df, hearingRequirements_df_audit = L.hearingRequirements(silver_m1, silver_m3, silver_c, bronze_interpreter_languages)\n",
     "    substantiveDecision_df, substantiveDecision_df_audit = DA.substantiveDecision(silver_m1,silver_m3)\n",
     "    hearingActuals_df, hearingActuals_df_audit = DA.hearingActuals(silver_m1, silver_m3)\n",
-    "    ftpaDec_df, ftpa_df_audit = FTD.ftpa(silver_m1, silver_m3,silver_c) \n",
+    "    ftpaDec_df, ftpa_df_audit = FTD.ftpa(silver_m1, silver_m2, silver_m3,silver_c) \n",
     "    detainedState_df, detainedState_df_audit = PPD.detained(silver_m1,silver_m2,bronze_detention_centres)\n",
     "\n",
     "    silver_segmentation_df = silver_segmentation\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_A_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_A_JSON.ipynb
@@ -624,7 +624,7 @@
    },
    "outputs": [],
    "source": [
-    "df,df_audit = FSA.ftpa(silver_m1, silver_m3, silver_c)\n",
+    "df,df_audit = FSA.ftpa(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "# display(df)"
    ]
   },
@@ -790,7 +790,7 @@
     "    hearingRequirements_df, hearingRequirements_df_audit = L.hearingRequirements(silver_m1, silver_m3, silver_c, bronze_interpreter_languages)\n",
     "    substantiveDecision_df, substantiveDecision_df_audit = DA.substantiveDecision(silver_m1,silver_m3)\n",
     "    hearingActuals_df, hearingActuals_df_audit = DA.hearingActuals(silver_m1, silver_m3)\n",
-    "    ftpa_df, ftpa_df_audit = FSA.ftpa(silver_m1, silver_m3,silver_c)\n",
+    "    ftpa_df, ftpa_df_audit = FSA.ftpa(silver_m1, silver_m2, silver_m3,silver_c)\n",
     "    detainedState_df, detainedState_df_audit = PPD.detained(silver_m1,silver_m2,bronze_detention_centres)\n",
     "\n",
     "    silver_segmentation_df = silver_segmentation\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_B_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_B_JSON.ipynb
@@ -625,7 +625,7 @@
    },
    "outputs": [],
    "source": [
-    "df,df_audit = FSB.ftpa(silver_m1, silver_m3, silver_c)\n",
+    "df,df_audit = FSB.ftpa(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "# display(df)"
    ]
   },
@@ -791,7 +791,7 @@
     "    hearingRequirements_df, hearingRequirements_df_audit = L.hearingRequirements(silver_m1, silver_m3, silver_c, bronze_interpreter_languages)\n",
     "    substantiveDecision_df, substantiveDecision_df_audit = DA.substantiveDecision(silver_m1,silver_m3)\n",
     "    hearingActuals_df, hearingActuals_df_audit = DA.hearingActuals(silver_m1, silver_m3)\n",
-    "    ftpa_df, ftpa_df_audit = FSB.ftpa(silver_m1, silver_m3,silver_c)\n",
+    "    ftpa_df, ftpa_df_audit = FSB.ftpa(silver_m1, silver_m2, silver_m3,silver_c)\n",
     "    detainedState_df, detainedState_df_audit = PPD.detained(silver_m1,silver_m2,bronze_detention_centres)\n",
     "\n",
     "    silver_segmentation_df = silver_segmentation\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_REMITTED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_REMITTED_JSON.ipynb
@@ -640,16 +640,19 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
+     "finishTime": 1782310357176,
      "inputWidgets": {},
      "nuid": "5c6309c9-7259-4cfc-9365-7d8410be94ad",
      "showTitle": true,
+     "startTime": 1782310352498,
+     "submitTime": 1782310352410,
      "tableResultSettingsMap": {},
      "title": "Function: ftpa"
     }
    },
    "outputs": [],
    "source": [
-    "ftpaDec_df, ftpa_audit = FTD.ftpa(silver_m1, silver_m3, silver_c)\n",
+    "ftpaDec_df, ftpa_audit = FTD.ftpa(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "# display(ftpaDec_df)"
    ]
   },
@@ -815,7 +818,7 @@
     "    hearingRequirements_df, hearingRequirements_df_audit = L.hearingRequirements(silver_m1, silver_m3, silver_c, bronze_interpreter_languages)\n",
     "    substantiveDecision_df, substantiveDecision_df_audit = DA.substantiveDecision(silver_m1,silver_m3)\n",
     "    hearingActuals_df, hearingActuals_df_audit = DA.hearingActuals(silver_m1,silver_m3)\n",
-    "    ftpaDec_df, ftpa_df_audit = FTD.ftpa(silver_m1,silver_m3,silver_c)\n",
+    "    ftpaDec_df, ftpa_df_audit = FTD.ftpa(silver_m1, silver_m2, silver_m3,silver_c)\n",
     "    remittal_df, remittal_df_audit = R.remittal(silver_m1,silver_m3)\n",
     "    detainedState_df, detainedState_df_audit = PPD.detained(silver_m1,silver_m2,bronze_detention_centres)\n",
     "\n",

--- a/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
@@ -7,12 +7,13 @@ from shared_functions.dq_rules import (
 )
 from pyspark.sql import Window
 from pyspark.sql.functions import (coalesce, col, collect_list, lit, row_number, struct, when, min, max, date_format, to_timestamp,
-                                   array_min, transform, array, abs, concat_ws, concat, array_contains)
-from pyspark.sql.types import ArrayType, LongType
+                                   array_min, transform, array, abs, concat_ws, concat, array_contains, lower, udf)
+from pyspark.sql.types import ArrayType, LongType, StringType
 
 # import shared_functions.ended as E
 from . import ended as E
 from .paymentPending import derive_country_silver_m2
+from uk_postcodes_parsing import fix, postcode_utils
 
 logger = logging.getLogger(__name__)
 
@@ -331,8 +332,100 @@ def build_dq_rules_dependencies(df_final, silver_m1, silver_m2, silver_m3, silve
     judges_per_case_single = (silver_m6_conditional.groupBy("CaseNo").agg(min("Required").alias("Required"), 
                                                                           concat_ws("\n", collect_list("formatted_judge")).alias("Judges"))
                               )
-
     
+    #decided_a ftpaApplicationDeadline
+
+    def getUkPostcode(postcode):
+        try:
+            if postcode is None or str(postcode).strip() == "":
+                return "False"
+            if postcode_utils.is_valid(postcode):
+                return "True"
+            clean_postcode = fix(postcode)
+            if postcode_utils.is_valid(clean_postcode):
+                return "True"
+        except Exception as e:
+            print(f"Error processing {postcode}: {e}")
+            pass
+        return "False"
+
+    getUkPostcodeUDF = udf(getUkPostcode, StringType())
+
+    ftpaInOrOut_lookup = (
+        silver_m2
+        .join(silver_c, on="CaseNo", how="left")
+        .withColumn(
+            "stage_detained",
+            when(col("Detained") == 3, lit("OOC"))
+            .otherwise(lit(None))
+        )
+        .withColumn(
+            "stage_category",
+            when(
+                col("stage_detained").isNull(),
+                when(col("CategoryId") == 37, lit("IN"))
+                .when(col("CategoryId") == 38, lit("OUT"))
+            )
+        )
+        .withColumn(
+            "stage_country",
+            when(
+                col("stage_detained").isNull() &
+                col("stage_category").isNull(),
+                when(col("AppellantCountryId") == 188, lit("IN"))
+            )
+        )
+        .withColumn(
+            "stage_postcode",
+            when(
+                col("stage_detained").isNull() &
+                col("stage_category").isNull() &
+                col("stage_country").isNull(),
+                when(getUkPostcodeUDF(col("Appellant_Postcode")) == "True", lit("IN"))
+            )
+        )
+        .withColumn("appellantFullAddress", concat_ws(", ",
+                col("Appellant_Address1"), col("Appellant_Address2"),
+                col("Appellant_Address3"), col("Appellant_Address4"),
+                col("Appellant_Address5"), col("Appellant_Postcode")
+            ))
+        .withColumn(
+            "stage_address",
+            when(
+                col("stage_detained").isNull() &
+                col("stage_category").isNull() &
+                col("stage_country").isNull() &
+                col("stage_postcode").isNull(),
+                when(
+                    lower(col("appellantFullAddress")).rlike(r"\b(uk|gb|united kingdom)\b") == True,
+                    lit("IN")
+                )
+            )
+        )
+        .withColumn(
+            "INorOUT",
+            coalesce(
+                col("stage_detained"),
+                col("stage_category"),
+                col("stage_country"),
+                col("stage_postcode"),
+                col("stage_address"),
+                lit("OOC")
+            )
+        )
+        .withColumn("rn", row_number().over(
+            Window.partitionBy("CaseNo").orderBy(
+                when(col("INorOUT") == "IN", 0).otherwise(1)
+            )
+        ))
+        .filter(col("rn") == 1)
+        .select(col("CaseNo"), col("INorOUT"), col("stage_detained"), col("stage_category"), col("stage_country"), col("stage_postcode"), col("stage_address"))
+    )
+
+    silver_m1_with_in_or_out = (
+        silver_m1.select("CaseNo")
+        .join(ftpaInOrOut_lookup, on="CaseNo", how="left")
+    )
 
 
     # ftpaSubmitted - ftpa - decided(b)
@@ -447,7 +540,7 @@ def build_dq_rules_dependencies(df_final, silver_m1, silver_m2, silver_m3, silve
     silver_m3_max_statusid_state_2_3_4 = silver_m3_ranked_state_2_3_4.filter(col("row_number") == 1).drop("row_number").select(col("CaseNo"),col("StatusId"),col("CaseStatus"),col("Outcome"))
 
     df_documents, df_documents_audit = E.documents(silver_m1,silver_m3)
-    df_ftpa, df_ftpa_audit = E.ftpa(silver_m1,silver_m3,silver_c)
+    df_ftpa, df_ftpa_audit = E.ftpa(silver_m1, silver_m2, silver_m3,silver_c)
     df_general, df_general_audit = E.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)
     df_generalDefault = E.generalDefault(silver_m1,silver_m3)
     df_hearingRequirements, df_hearingRequirements_audit = E.hearingRequirements(silver_m1, silver_m3, silver_c, bronze_interpreter_languages)
@@ -581,6 +674,7 @@ def build_dq_rules_dependencies(df_final, silver_m1, silver_m2, silver_m3, silve
             .join(detained_df, on="CaseNo", how="left")
             .join(cs46_out31, on="CaseNo", how="left")
             .join(silver_m3_max_casestatus_no_filter, on="CaseNo", how="left")
+            .join(silver_m1_with_in_or_out, on="CaseNo", how="left")
             .withColumn("valid_categoryIdList", coalesce(col("valid_categoryIdList"), array()))  # No need to add extra categoryIdList IS NULL rules in the DQ.
             .withColumn("lu_HORef", coalesce(col("lu_HORef"), col("HORef"), col("FCONumber")))  # HORef in conditionals can also come from silver_m1, not just the bronze cleansing. The bronze cleansing will be used as priority.
             .withColumn("dv_appellantIsInUk",

--- a/Databricks/ACTIVE/APPEALS/shared_functions/decided_a.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/decided_a.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pyspark.sql import functions as F
 from pyspark.sql.window import Window
 from pyspark.sql.types import StringType
+from uk_postcodes_parsing import fix, postcode_utils
 from . import AwaitingEvidenceRespondant_b as AERb
 from . import listing as L
 from . import prepareForHearing as PFH
@@ -18,7 +19,7 @@ from pyspark.sql.functions import (
     col, when, lit, array, struct, collect_list, 
     max as spark_max, date_format, row_number, expr, regexp_replace,
     size, udf, coalesce, concat_ws, concat, trim, year, split, datediff,
-    collect_set, current_timestamp,transform, first, array_contains,rank,create_map, map_from_entries, map_from_arrays
+    collect_set, current_timestamp,transform, first, array_contains,rank,create_map, map_from_entries, map_from_arrays, date_add, lower
 )
 
 
@@ -99,32 +100,6 @@ def substantiveDecision(silver_m1,silver_m3):
                 lit("No").alias("anonymityOrder")
             )
     )
-
-    
-    # substantiveDecision_df = (
-    #     substantiveDecision_df.alias("sd")
-    #         .join(silver_m3_max_statusid.alias("m3"), on=["CaseNo"], how="left")
-    #         .select(
-    #             col("sd.*"),
-    #             # Format dates as dd/MM/yyyy
-    #             date_format(col("m3.DecisionDate"), "dd/MM/yyyy").alias("sendDecisionsAndReasonsDate"),
-    #             date_format(col("m3.DecisionDate"), "dd/MM/yyyy").alias("appealDate"),
-
-    #             # Outcome mapping
-    #             when(col("m3.Outcome") == 1, "Allowed")
-    #                 .when(col("m3.Outcome") == 2, "Dismissed")
-    #                 .otherwise(None)
-    #                 .alias("appealDecision"),
-
-    #             when(col("m3.Outcome") == 1, "Allowed")
-    #                 .when(col("m3.Outcome") == 2, "Dismissed")
-    #                 .otherwise(None)
-    #                 .alias("isDecisionAllowed"),
-
-    #             lit("No").alias("anonymityOrder")
-    #         )
-    # )
-
 
     substantiveDecision_audit = (
         substantiveDecision_audit.alias("audit")
@@ -230,7 +205,107 @@ def hearingActuals(silver_m1, silver_m3):
 ##########              ftpa          ###########
 ################################################################
 
-def ftpa(silver_m1, silver_m3,silver_c):
+def ftpa(silver_m1, silver_m2, silver_m3,silver_c):
+
+    def getUkPostcode(postcode):
+        try:
+            if postcode is None or str(postcode).strip() == "":
+                return "False"
+            
+            # Step 1: Check if postcode is valid
+            if postcode_utils.is_valid(postcode):
+                return "True"
+            
+            # Step 2: Try fixing the postcode if not valid
+            clean_postcode = fix(postcode)
+            if postcode_utils.is_valid(clean_postcode):
+                return "True"
+
+        except Exception as e:
+            print(f"Error processing {postcode}: {e}")
+            pass
+
+        return "False"
+
+    getUkPostcodeUDF = udf(getUkPostcode, StringType())
+
+    ftpaApplicationDate_flags = (
+        silver_m2
+        .join(silver_c, on="CaseNo", how="left")
+        .withColumn(
+            "stage_detained",
+            when(col("Detained") == 3, lit("OOC"))
+            .otherwise(lit(None))
+        )
+        .withColumn(
+            "stage_category",
+            when(
+                col("stage_detained").isNull(),
+                when(col("CategoryId") == 37, lit("IN"))
+                .when(col("CategoryId") == 38, lit("OUT"))
+            )
+        )
+        .withColumn(
+            "stage_country",
+            when(
+                col("stage_detained").isNull() &
+                col("stage_category").isNull(),
+                when(col("AppellantCountryId") == 188, lit("IN"))
+            )
+        )
+        .withColumn(
+            "stage_postcode",
+            when(
+                col("stage_detained").isNull() &
+                col("stage_category").isNull() &
+                col("stage_country").isNull(),
+                when(
+                    getUkPostcodeUDF(col("Appellant_Postcode")) == "True",
+                    lit("IN")
+                )
+            )
+        )
+        .withColumn("appellantFullAddress", concat_ws(", ",
+                col("Appellant_Address1"), col("Appellant_Address2"),
+                col("Appellant_Address3"), col("Appellant_Address4"),
+                col("Appellant_Address5"), col("Appellant_Postcode")
+            ))
+        .withColumn(
+            "stage_address",
+            when(
+                col("stage_detained").isNull() &
+                col("stage_category").isNull() &
+                col("stage_country").isNull() &
+                col("stage_postcode").isNull(),
+                when(
+                    lower(col("appellantFullAddress")).rlike(
+                        r"\b(uk|gb|united kingdom)\b") == True, lit("IN")
+                )
+            )
+        )
+        .withColumn(
+            "IN or OUT",
+            coalesce(
+                col("stage_detained"),
+                col("stage_category"),
+                col("stage_country"),
+                col("stage_postcode"),
+                col("stage_address"),
+                lit("OOC")
+            )
+        )
+        .select(
+            "CaseNo",
+            "Detained",
+            "CategoryId",
+            "stage_detained",
+            "stage_category",
+            "stage_country",
+            "stage_postcode",
+            "stage_address",
+            "IN or OUT"
+        )
+    )
 
     window_spec = Window.partitionBy("CaseNo").orderBy(col("StatusId").desc())
 
@@ -248,21 +323,49 @@ def ftpa(silver_m1, silver_m3,silver_c):
         .drop("rn")
     )
 
-    ftpa_df = (
+    ftpa_flags_filtered = (
         silver_m1.alias("m1")
-            .join(join_df, on="CaseNo", how="left")
+        .join(ftpaApplicationDate_flags.alias("ftpa"), on="CaseNo", how="inner")
+        .join(join_df.alias("m3_c"), on="CaseNo", how="left")
+        .select(
+            col("CaseNo"),
+            col("m3_c.CategoryId"),
+            col("m3_c.CaseStatus"),
+            col("m3_c.Outcome"),
+            col("m3_c.DecisionDate"),
+            "stage_detained",
+            "stage_category",
+            "stage_country",
+            "stage_postcode",
+            "stage_address",
+            col("IN or OUT")
+        )
+        .distinct()
+    )
+
+    ftpa_flags_filtered_deduped = Window.partitionBy("CaseNo").orderBy(
+        when(col("IN or OUT") == "IN", 0).otherwise(1)
+    )
+
+    ftpaApplicationDate_flags_deduped = (
+        ftpa_flags_filtered
+        .withColumn("rn", row_number().over(ftpa_flags_filtered_deduped))
+        .filter(col("rn") == 1)
+        .drop("rn")
+    )
+
+    ftpa_df = (
+        ftpaApplicationDate_flags_deduped
             .select(
                 col("CaseNo"),
                 date_format(
-                    when(col("CategoryId") == 37, F.date_add(col("DecisionDate"), 14))
-                    .when(col("CategoryId") == 38, F.date_add(col("DecisionDate"), 28))
-                    .otherwise(col("DecisionDate")),
+                    when(col("IN or OUT") == "IN", date_add(col("DecisionDate"), 14))
+                    .when(col("IN or OUT") == "OOC", date_add(col("DecisionDate"), 28)),
                     "yyyy-MM-dd"
                 ).alias("ftpaApplicationDeadline")
             )
-        )
+    )
 
-    # Build the audit DataFrame
     ftpa_audit = (
         ftpa_df.alias("ftpa")
             .join(join_df.alias("m3"), on=["CaseNo"], how="left")
@@ -288,9 +391,8 @@ def ftpa(silver_m1, silver_m3,silver_c):
                 lit("Yes").alias("ftpaApplicationDeadline_Transformation"),
             )
     )
-
-
     return ftpa_df, ftpa_audit
+
 ################################################################
 
 ################################################################

--- a/Databricks/ACTIVE/APPEALS/shared_functions/decided_b.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/decided_b.py
@@ -210,9 +210,9 @@ def setAside(silver_m1, silver_m3, silver_m6):
 ##########              ftpa          ###########
 ################################################################
 
-def ftpa(silver_m1, silver_m3,silver_c):
+def ftpa(silver_m1, silver_m2, silver_m3,silver_c):
 
-    ftpa_df,ftpa_audit = FSA.ftpa(silver_m1, silver_m3,silver_c)
+    ftpa_df,ftpa_audit = FSA.ftpa(silver_m1, silver_m2, silver_m3,silver_c)
 
     ftpa_df = ftpa_df.drop("ftpaList")
     ftpa_audit = ftpa_audit.drop("ftpaList_value","ftpaList_inputFields","ftpaList_inputValues","ftpaList_Transformation")

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
@@ -164,34 +164,35 @@ class decidedADQRules(DQRulesBase):
         return checks
 
     def get_checks_ftpa(self, checks={}):
-        
+
         checks["valid_ftpaApplicationDeadline"] = """
         (
             (
                 CASE
-                    WHEN Outcome_SD IN (1, 2)
-                        AND CaseStatus_SD IN (37, 38, 26)
-                        AND CategoryId = 37
+                    WHEN INorOUT = 'IN'
                     THEN
                         to_date(ftpaApplicationDeadline) = to_date(date_add(DecisionDate_decided, 14))
 
-                    WHEN Outcome_SD IN (1, 2)
-                        AND CaseStatus_SD IN (37, 38, 26)
-                        AND CategoryId = 38
+                    WHEN INorOUT = 'OOC'
                     THEN
                         to_date(ftpaApplicationDeadline) = to_date(date_add(DecisionDate_decided, 28))
+
+                    WHEN INorOUT = 'OOC' OR INorOUT IS NULL
+                    THEN
+                        ftpaApplicationDeadline IS NULL
                 END
             )
             OR
             (
-                (
-                    (Outcome_SD IS NULL OR Outcome_SD NOT IN (1,2))
-                    OR (CaseStatus_SD IS NULL OR CaseStatus_SD NOT IN (37,38,26))
-                    OR (CategoryId IS NULL OR CategoryId NOT IN (37,38))
-                )
-                AND ftpaApplicationDeadline IS NULL
+                ftpaApplicationDeadline IS NULL AND (stage_detained = "OOC" OR stage_category = "OOC" OR stage_country = "OOC" 
+                OR stage_postcode = "OOC" OR stage_address = "OOC")
+            )
+            OR
+            (
+                ftpaApplicationDeadline IS NULL AND DecisionDate_decided IS NULL
             )
         )
         """
+
         return checks
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/ended.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/ended.py
@@ -1444,9 +1444,9 @@ def hearingActuals(silver_m1,silver_m3):
 ################################################################
 
 
-def ftpa(silver_m1, silver_m3, silver_c):
+def ftpa(silver_m1, silver_m2, silver_m3, silver_c):
 
-    ftpa_df, ftpa_audit = FSA.ftpa(silver_m1, silver_m3, silver_c)
+    ftpa_df, ftpa_audit = FSA.ftpa(silver_m1, silver_m2, silver_m3, silver_c)
 
     
     # NOTE: DecisionDate may not exist in some unit test schemas. This ordering expects it exists in decided runs.

--- a/Databricks/ACTIVE/APPEALS/shared_functions/ftpa_decided.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/ftpa_decided.py
@@ -29,7 +29,7 @@ from pyspark.sql.functions import (
 ##########              ftpa (Field Group)          ###########
 ################################################################
 
-def ftpa(silver_m1, silver_m3, silver_c):
+def ftpa(silver_m1, silver_m2, silver_m3, silver_c):
     """
     Mapping alignment
       - Decision/outcome fields (ftpaFirstDecision, DecisionDates, FinalDecisionForDisplay, RJ outcome types, ApplicantType)
@@ -47,7 +47,7 @@ def ftpa(silver_m1, silver_m3, silver_c):
     """
 
     # Base ftpa fields (judge allocation etc.)
-    ftpa_df, ftpa_audit = FSB.ftpa(silver_m1, silver_m3, silver_c)
+    ftpa_df, ftpa_audit = FSB.ftpa(silver_m1, silver_m2, silver_m3, silver_c)
 
     # NOTE: DecisionDate may not exist in some unit test schemas. This ordering expects it exists in decided runs.
     window_spec = (

--- a/Databricks/ACTIVE/APPEALS/shared_functions/ftpa_submitted_a.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/ftpa_submitted_a.py
@@ -119,9 +119,9 @@ def documents(silver_m1,silver_m3):
 ##########              ftpa          ###########
 ################################################################
 
-def ftpa(silver_m1,silver_m3,silver_c):
+def ftpa(silver_m1, silver_m2, silver_m3, silver_c):
 
-    ftpa_df,ftpa_audit = DA.ftpa(silver_m1,silver_m3,silver_c)
+    ftpa_df,ftpa_audit = DA.ftpa(silver_m1, silver_m2, silver_m3, silver_c)
 
     window_spec = Window.partitionBy("CaseNo").orderBy(col("StatusId").desc())
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/ftpa_submitted_b.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/ftpa_submitted_b.py
@@ -27,9 +27,9 @@ from pyspark.sql.functions import (
 ##########              ftpa          ###########
 ################################################################
 
-def ftpa(silver_m1,silver_m3,silver_c):
+def ftpa(silver_m1, silver_m2, silver_m3,silver_c):
 
-    ftpa_df,ftpa_audit = FSA.ftpa(silver_m1,silver_m3,silver_c)
+    ftpa_df,ftpa_audit = FSA.ftpa(silver_m1, silver_m2, silver_m3,silver_c)
 
     window_spec = Window.partitionBy("CaseNo").orderBy(col("StatusId").desc())
 

--- a/tests/active/decided_a/ftpa_test.py
+++ b/tests/active/decided_a/ftpa_test.py
@@ -133,7 +133,7 @@ def test_ftpaApplicationDeadline(spark,ftpa_outputs):
 
     results = ftpa_outputs
 
-    assert results["CASE005"]["ftpaApplicationDeadline"] == "2025-11-16"
+    assert results["CASE005"]["ftpaApplicationDeadline"] == "2025-11-30" #detained = 3, +28 days
     assert results["CASE006"]["ftpaApplicationDeadline"] == None
     assert results["CASE007"]["ftpaApplicationDeadline"] == None
     assert results["CASE010"]["ftpaApplicationDeadline"] == None

--- a/tests/active/decided_a/ftpa_test.py
+++ b/tests/active/decided_a/ftpa_test.py
@@ -49,18 +49,33 @@ def ftpa_outputs(spark):
         ]
     
     m2_schema = T.StructType([
-    T.StructField("CaseNo", T.StringType(), True),
-    T.StructField("Appellant_Name", T.StringType(), True),
-    T.StructField("Appellant_Postcode", T.StringType(), True),
-    T.StructField("Relationship", T.StringType(), True)])
-    
+        T.StructField("CaseNo", T.StringType(), True),
+        T.StructField("Detained", T.IntegerType(), True),
+        T.StructField("AppellantCountryId", T.IntegerType(), True),
+        T.StructField("Appellant_Postcode", T.StringType(), True),
+        T.StructField("Appellant_Address1", T.StringType(), True),
+        T.StructField("Appellant_Address2", T.StringType(), True),
+        T.StructField("Appellant_Address3", T.StringType(), True),
+        T.StructField("Appellant_Address4", T.StringType(), True),
+        T.StructField("Appellant_Address5", T.StringType(), True),
+    ])
+
     m2_data = [
-        ("CASE001", "Gold", "B12 0hf","Relationship1"),  
-        ("CASE002", "Smith", "M8 1XY","Relationship2"),  
-        ("CASE003", "Johns", "DE4 9HN","Relationship3"),  
-        ("CASE004", "Black", "BN6 0PA","Relationship4"),  
-        ("CASE005", "Green", "DD7 7PT",None), 
-        ]
+        # stage_detained: Detained==3 → OOC (short-circuits everything)
+        ("CASE005", 3,    None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==37 → IN
+        ("CASE006", None, None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==38 → OUT
+        ("CASE007", None, None, None,      None,           None, None, None, None),
+        # stage_country: AppellantCountryId==188 → IN
+        ("CASE008", None, 188,  None,      None,           None, None, None, None),
+        # stage_postcode: valid UK postcode → IN
+        ("CASE009", None, None, "B12 0HF", None,           None, None, None, None),
+        # stage_address: address contains "united kingdom" → IN
+        ("CASE010", None, None, None,      "123 Some Road","Birmingham","United Kingdom", None, None),
+        # falls through all stages → OOC
+        ("CASE011", None, None, None,      "123 Rue de la Paix", "Paris", "France", None, None),
+    ]
 
     m3_schema = T.StructType([
         T.StructField("CaseNo", T.StringType(), True),

--- a/tests/active/decided_a/ftpa_test.py
+++ b/tests/active/decided_a/ftpa_test.py
@@ -109,7 +109,7 @@ def ftpa_outputs(spark):
     df_c =  spark.createDataFrame(c_data, c_schema)
 
 
-    ftpa_content,_ = ftpa(df_m1,df_m3, df_c)
+    ftpa_content,_ = ftpa(df_m1, df_m2, df_m3, df_c)
     results = {row["CaseNo"]: row.asDict() for row in ftpa_content.collect()}
     
     return results

--- a/tests/active/decided_a/ftpa_test.py
+++ b/tests/active/decided_a/ftpa_test.py
@@ -134,7 +134,7 @@ def test_ftpaApplicationDeadline(spark,ftpa_outputs):
     results = ftpa_outputs
 
     assert results["CASE005"]["ftpaApplicationDeadline"] == "2025-11-16"
-    assert results["CASE006"]["ftpaApplicationDeadline"] == "2026-12-31"
+    assert results["CASE006"]["ftpaApplicationDeadline"] == None
     assert results["CASE007"]["ftpaApplicationDeadline"] == None
     assert results["CASE010"]["ftpaApplicationDeadline"] == None
 

--- a/tests/active/decided_b/ftpa_test.py
+++ b/tests/active/decided_b/ftpa_test.py
@@ -48,6 +48,19 @@ def ftpa_outputs(spark):
         ("CASE011", "AIP", "FT", None, 0, 0, True, 61,0, "B12 0hf", "B12 0hf",1,"Man")
         ]
 
+    m2_schema = T.StructType([
+    T.StructField("CaseNo", T.StringType(), True),
+    T.StructField("Appellant_Name", T.StringType(), True),
+    T.StructField("Appellant_Postcode", T.StringType(), True),
+    T.StructField("Relationship", T.StringType(), True)])
+    
+    m2_data = [
+        ("CASE001", "Gold", "B12 0hf","Relationship1"),  
+        ("CASE002", "Smith", "M8 1XY","Relationship2"),  
+        ("CASE003", "Johns", "DE4 9HN","Relationship3"),  
+        ("CASE004", "Black", "BN6 0PA","Relationship4"),  
+        ("CASE005", "Green", "DD7 7PT",None), 
+        ]
 
     m3_schema = T.StructType([
         T.StructField("CaseNo", T.StringType(), True),
@@ -100,11 +113,12 @@ def ftpa_outputs(spark):
         ]
     
     df_m1 =  spark.createDataFrame(m1_data, m1_schema)
+    df_m2 =  spark.createDataFrame(m2_data, m2_schema)
     df_m3 =  spark.createDataFrame(m3_data, m3_schema)
     df_c =  spark.createDataFrame(c_data, c_schema)
 
 
-    ftpa_content,_ = ftpa(df_m1,df_m3, df_c)
+    ftpa_content,_ = ftpa(df_m1, df_m2, df_m3, df_c)
     results = {row["CaseNo"]: row.asDict() for row in ftpa_content.collect()}
     
     return results

--- a/tests/active/decided_b/ftpa_test.py
+++ b/tests/active/decided_b/ftpa_test.py
@@ -49,18 +49,33 @@ def ftpa_outputs(spark):
         ]
 
     m2_schema = T.StructType([
-    T.StructField("CaseNo", T.StringType(), True),
-    T.StructField("Appellant_Name", T.StringType(), True),
-    T.StructField("Appellant_Postcode", T.StringType(), True),
-    T.StructField("Relationship", T.StringType(), True)])
-    
+        T.StructField("CaseNo", T.StringType(), True),
+        T.StructField("Detained", T.IntegerType(), True),
+        T.StructField("AppellantCountryId", T.IntegerType(), True),
+        T.StructField("Appellant_Postcode", T.StringType(), True),
+        T.StructField("Appellant_Address1", T.StringType(), True),
+        T.StructField("Appellant_Address2", T.StringType(), True),
+        T.StructField("Appellant_Address3", T.StringType(), True),
+        T.StructField("Appellant_Address4", T.StringType(), True),
+        T.StructField("Appellant_Address5", T.StringType(), True),
+    ])
+
     m2_data = [
-        ("CASE001", "Gold", "B12 0hf","Relationship1"),  
-        ("CASE002", "Smith", "M8 1XY","Relationship2"),  
-        ("CASE003", "Johns", "DE4 9HN","Relationship3"),  
-        ("CASE004", "Black", "BN6 0PA","Relationship4"),  
-        ("CASE005", "Green", "DD7 7PT",None), 
-        ]
+        # stage_detained: Detained==3 → OOC (short-circuits everything)
+        ("CASE005", 3,    None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==37 → IN
+        ("CASE006", None, None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==38 → OUT
+        ("CASE007", None, None, None,      None,           None, None, None, None),
+        # stage_country: AppellantCountryId==188 → IN
+        ("CASE008", None, 188,  None,      None,           None, None, None, None),
+        # stage_postcode: valid UK postcode → IN
+        ("CASE009", None, None, "B12 0HF", None,           None, None, None, None),
+        # stage_address: address contains "united kingdom" → IN
+        ("CASE010", None, None, None,      "123 Some Road","Birmingham","United Kingdom", None, None),
+        # falls through all stages → OOC
+        ("CASE011", None, None, None,      "123 Rue de la Paix", "Paris", "France", None, None),
+    ]
 
     m3_schema = T.StructType([
         T.StructField("CaseNo", T.StringType(), True),

--- a/tests/active/ftpa_decided/ftpa_test.py
+++ b/tests/active/ftpa_decided/ftpa_test.py
@@ -44,6 +44,20 @@ def ftpa_outputs(spark):
         ("CASE011", "AIP", "FT", None, 0, 0, True, 61,0, "B12 0hf", "B12 0hf",1,"Man")
         ]
 
+    m2_schema = T.StructType([
+    T.StructField("CaseNo", T.StringType(), True),
+    T.StructField("Appellant_Name", T.StringType(), True),
+    T.StructField("Appellant_Postcode", T.StringType(), True),
+    T.StructField("Relationship", T.StringType(), True)])
+    
+    m2_data = [
+        ("CASE001", "Gold", "B12 0hf","Relationship1"),  
+        ("CASE002", "Smith", "M8 1XY","Relationship2"),  
+        ("CASE003", "Johns", "DE4 9HN","Relationship3"),  
+        ("CASE004", "Black", "BN6 0PA","Relationship4"),  
+        ("CASE005", "Green", "DD7 7PT",None), 
+        ]
+
     m3_schema = T.StructType([
         T.StructField("CaseNo", T.StringType(), True),
         T.StructField("StatusId", T.IntegerType(), True),
@@ -80,10 +94,11 @@ def ftpa_outputs(spark):
     ]
 
     silver_m1 =  spark.createDataFrame(m1_data, m1_schema)
+    df_m2 =  spark.createDataFrame(m2_data, m2_schema)
     silver_m3 = spark.createDataFrame(m3_data, m3_schema)
     silver_c = spark.createDataFrame(c_data, c_schema)
 
-    ftpa_content, _ = ftpa(silver_m1,silver_m3, silver_c)
+    ftpa_content, _ = ftpa(silver_m1, silver_m2, silver_m3, silver_c)
 
     results = {row["CaseNo"]: row.asDict() for row in ftpa_content.collect()}
     return results

--- a/tests/active/ftpa_decided/ftpa_test.py
+++ b/tests/active/ftpa_decided/ftpa_test.py
@@ -45,18 +45,33 @@ def ftpa_outputs(spark):
         ]
 
     m2_schema = T.StructType([
-    T.StructField("CaseNo", T.StringType(), True),
-    T.StructField("Appellant_Name", T.StringType(), True),
-    T.StructField("Appellant_Postcode", T.StringType(), True),
-    T.StructField("Relationship", T.StringType(), True)])
-    
+        T.StructField("CaseNo", T.StringType(), True),
+        T.StructField("Detained", T.IntegerType(), True),
+        T.StructField("AppellantCountryId", T.IntegerType(), True),
+        T.StructField("Appellant_Postcode", T.StringType(), True),
+        T.StructField("Appellant_Address1", T.StringType(), True),
+        T.StructField("Appellant_Address2", T.StringType(), True),
+        T.StructField("Appellant_Address3", T.StringType(), True),
+        T.StructField("Appellant_Address4", T.StringType(), True),
+        T.StructField("Appellant_Address5", T.StringType(), True),
+    ])
+
     m2_data = [
-        ("CASE001", "Gold", "B12 0hf","Relationship1"),  
-        ("CASE002", "Smith", "M8 1XY","Relationship2"),  
-        ("CASE003", "Johns", "DE4 9HN","Relationship3"),  
-        ("CASE004", "Black", "BN6 0PA","Relationship4"),  
-        ("CASE005", "Green", "DD7 7PT",None), 
-        ]
+        # stage_detained: Detained==3 → OOC (short-circuits everything)
+        ("CASE005", 3,    None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==37 → IN
+        ("CASE006", None, None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==38 → OUT
+        ("CASE007", None, None, None,      None,           None, None, None, None),
+        # stage_country: AppellantCountryId==188 → IN
+        ("CASE008", None, 188,  None,      None,           None, None, None, None),
+        # stage_postcode: valid UK postcode → IN
+        ("CASE009", None, None, "B12 0HF", None,           None, None, None, None),
+        # stage_address: address contains "united kingdom" → IN
+        ("CASE010", None, None, None,      "123 Some Road","Birmingham","United Kingdom", None, None),
+        # falls through all stages → OOC
+        ("CASE011", None, None, None,      "123 Rue de la Paix", "Paris", "France", None, None),
+    ]
 
     m3_schema = T.StructType([
         T.StructField("CaseNo", T.StringType(), True),

--- a/tests/active/ftpa_decided/ftpa_test.py
+++ b/tests/active/ftpa_decided/ftpa_test.py
@@ -109,7 +109,7 @@ def ftpa_outputs(spark):
     ]
 
     silver_m1 =  spark.createDataFrame(m1_data, m1_schema)
-    df_m2 =  spark.createDataFrame(m2_data, m2_schema)
+    silver_m2 =  spark.createDataFrame(m2_data, m2_schema)
     silver_m3 = spark.createDataFrame(m3_data, m3_schema)
     silver_c = spark.createDataFrame(c_data, c_schema)
 

--- a/tests/active/ftpa_submitted_a/ftpa_test.py
+++ b/tests/active/ftpa_submitted_a/ftpa_test.py
@@ -49,18 +49,33 @@ def ftpa_outputs(spark):
         ]
 
     m2_schema = T.StructType([
-    T.StructField("CaseNo", T.StringType(), True),
-    T.StructField("Appellant_Name", T.StringType(), True),
-    T.StructField("Appellant_Postcode", T.StringType(), True),
-    T.StructField("Relationship", T.StringType(), True)])
-    
+        T.StructField("CaseNo", T.StringType(), True),
+        T.StructField("Detained", T.IntegerType(), True),
+        T.StructField("AppellantCountryId", T.IntegerType(), True),
+        T.StructField("Appellant_Postcode", T.StringType(), True),
+        T.StructField("Appellant_Address1", T.StringType(), True),
+        T.StructField("Appellant_Address2", T.StringType(), True),
+        T.StructField("Appellant_Address3", T.StringType(), True),
+        T.StructField("Appellant_Address4", T.StringType(), True),
+        T.StructField("Appellant_Address5", T.StringType(), True),
+    ])
+
     m2_data = [
-        ("CASE001", "Gold", "B12 0hf","Relationship1"),  
-        ("CASE002", "Smith", "M8 1XY","Relationship2"),  
-        ("CASE003", "Johns", "DE4 9HN","Relationship3"),  
-        ("CASE004", "Black", "BN6 0PA","Relationship4"),  
-        ("CASE005", "Green", "DD7 7PT",None), 
-        ]
+        # stage_detained: Detained==3 → OOC (short-circuits everything)
+        ("CASE005", 3,    None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==37 → IN
+        ("CASE006", None, None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==38 → OUT
+        ("CASE007", None, None, None,      None,           None, None, None, None),
+        # stage_country: AppellantCountryId==188 → IN
+        ("CASE008", None, 188,  None,      None,           None, None, None, None),
+        # stage_postcode: valid UK postcode → IN
+        ("CASE009", None, None, "B12 0HF", None,           None, None, None, None),
+        # stage_address: address contains "united kingdom" → IN
+        ("CASE010", None, None, None,      "123 Some Road","Birmingham","United Kingdom", None, None),
+        # falls through all stages → OOC
+        ("CASE011", None, None, None,      "123 Rue de la Paix", "Paris", "France", None, None),
+    ]
 
 
     m3_schema = T.StructType([

--- a/tests/active/ftpa_submitted_a/ftpa_test.py
+++ b/tests/active/ftpa_submitted_a/ftpa_test.py
@@ -48,6 +48,20 @@ def ftpa_outputs(spark):
         ("CASE011", "AIP", "FT", None, 0, 0, True, 61,0, "B12 0hf", "B12 0hf",1,"Man")
         ]
 
+    m2_schema = T.StructType([
+    T.StructField("CaseNo", T.StringType(), True),
+    T.StructField("Appellant_Name", T.StringType(), True),
+    T.StructField("Appellant_Postcode", T.StringType(), True),
+    T.StructField("Relationship", T.StringType(), True)])
+    
+    m2_data = [
+        ("CASE001", "Gold", "B12 0hf","Relationship1"),  
+        ("CASE002", "Smith", "M8 1XY","Relationship2"),  
+        ("CASE003", "Johns", "DE4 9HN","Relationship3"),  
+        ("CASE004", "Black", "BN6 0PA","Relationship4"),  
+        ("CASE005", "Green", "DD7 7PT",None), 
+        ]
+
 
     m3_schema = T.StructType([
         T.StructField("CaseNo", T.StringType(), True),
@@ -100,11 +114,12 @@ def ftpa_outputs(spark):
         ]
     
     df_m1 =  spark.createDataFrame(m1_data, m1_schema)
+    df_m2 =  spark.createDataFrame(m2_data, m2_schema)
     df_m3 =  spark.createDataFrame(m3_data, m3_schema)
     df_c =  spark.createDataFrame(c_data, c_schema)
 
 
-    ftpa_content,_ = ftpa(df_m1, df_m3, df_c)
+    ftpa_content,_ = ftpa(df_m1, df_m2, df_m3, df_c)
     results = {row["CaseNo"]: row.asDict() for row in ftpa_content.collect()}
     
     return results

--- a/tests/active/ftpa_submitted_b/ftpa_test.py
+++ b/tests/active/ftpa_submitted_b/ftpa_test.py
@@ -48,6 +48,20 @@ def ftpa_outputs(spark):
         ("CASE011", "AIP", "FT", None, 0, 0, True, 61,0, "B12 0hf", "B12 0hf",1,"Man")
         ]
 
+    m2_schema = T.StructType([
+    T.StructField("CaseNo", T.StringType(), True),
+    T.StructField("Appellant_Name", T.StringType(), True),
+    T.StructField("Appellant_Postcode", T.StringType(), True),
+    T.StructField("Relationship", T.StringType(), True)])
+    
+    m2_data = [
+        ("CASE001", "Gold", "B12 0hf","Relationship1"),  
+        ("CASE002", "Smith", "M8 1XY","Relationship2"),  
+        ("CASE003", "Johns", "DE4 9HN","Relationship3"),  
+        ("CASE004", "Black", "BN6 0PA","Relationship4"),  
+        ("CASE005", "Green", "DD7 7PT",None), 
+        ]
+
 
     m3_schema = T.StructType([
         T.StructField("CaseNo", T.StringType(), True),
@@ -100,11 +114,12 @@ def ftpa_outputs(spark):
         ]
     
     df_m1 =  spark.createDataFrame(m1_data, m1_schema)
+    df_m2 =  spark.createDataFrame(m2_data, m2_schema)
     df_m3 =  spark.createDataFrame(m3_data, m3_schema)
     df_c =  spark.createDataFrame(c_data, c_schema)
 
 
-    ftpa_content,_ = ftpa(df_m1, df_m3, df_c)
+    ftpa_content,_ = ftpa(df_m1, df_m2, df_m3, df_c)
     results = {row["CaseNo"]: row.asDict() for row in ftpa_content.collect()}
     
     return results

--- a/tests/active/ftpa_submitted_b/ftpa_test.py
+++ b/tests/active/ftpa_submitted_b/ftpa_test.py
@@ -49,19 +49,33 @@ def ftpa_outputs(spark):
         ]
 
     m2_schema = T.StructType([
-    T.StructField("CaseNo", T.StringType(), True),
-    T.StructField("Appellant_Name", T.StringType(), True),
-    T.StructField("Appellant_Postcode", T.StringType(), True),
-    T.StructField("Relationship", T.StringType(), True)])
-    
-    m2_data = [
-        ("CASE001", "Gold", "B12 0hf","Relationship1"),  
-        ("CASE002", "Smith", "M8 1XY","Relationship2"),  
-        ("CASE003", "Johns", "DE4 9HN","Relationship3"),  
-        ("CASE004", "Black", "BN6 0PA","Relationship4"),  
-        ("CASE005", "Green", "DD7 7PT",None), 
-        ]
+        T.StructField("CaseNo", T.StringType(), True),
+        T.StructField("Detained", T.IntegerType(), True),
+        T.StructField("AppellantCountryId", T.IntegerType(), True),
+        T.StructField("Appellant_Postcode", T.StringType(), True),
+        T.StructField("Appellant_Address1", T.StringType(), True),
+        T.StructField("Appellant_Address2", T.StringType(), True),
+        T.StructField("Appellant_Address3", T.StringType(), True),
+        T.StructField("Appellant_Address4", T.StringType(), True),
+        T.StructField("Appellant_Address5", T.StringType(), True),
+    ])
 
+    m2_data = [
+        # stage_detained: Detained==3 → OOC (short-circuits everything)
+        ("CASE005", 3,    None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==37 → IN
+        ("CASE006", None, None, None,      None,           None, None, None, None),
+        # stage_category: CategoryId==38 → OUT
+        ("CASE007", None, None, None,      None,           None, None, None, None),
+        # stage_country: AppellantCountryId==188 → IN
+        ("CASE008", None, 188,  None,      None,           None, None, None, None),
+        # stage_postcode: valid UK postcode → IN
+        ("CASE009", None, None, "B12 0HF", None,           None, None, None, None),
+        # stage_address: address contains "united kingdom" → IN
+        ("CASE010", None, None, None,      "123 Some Road","Birmingham","United Kingdom", None, None),
+        # falls through all stages → OOC
+        ("CASE011", None, None, None,      "123 Rue de la Paix", "Paris", "France", None, None),
+    ]
 
     m3_schema = T.StructType([
         T.StructField("CaseNo", T.StringType(), True),


### PR DESCRIPTION
Update logic in decided(a) where ftpaApplicationDeadline appears. silver_m2 needs added to parameters. All functions that call ftpa also need updated to pull in m2, hence ended, ftpaSubmittedA, ftpaSubmittedB, ftpaDecided, ended, remitted all contain updated in the .py and .ipynb. Note, it's only the function parameter being updated.

DQRules contains similar logic to derive an InorOUT field that the DQ checks in decided_a_dq_rules.py use to determine if a particular case is IN or OOC before appending 14 or 28 days. The rest of the DQ logic determines if the ftpaApplicationDeadline is null

All pipelines from decidedA onwards have been run and are behaving as expected. all ftpaApplicationDeadline DQs have been fixed.