### PR TITLE
HomeOfficeReferenceNumber default value

### DIFF
--- a/Databricks/ACTIVE/APPEALS/GOLD_AWAITING_EVIDENCE_RESPONDENT_A_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_AWAITING_EVIDENCE_RESPONDENT_A_JSON.ipynb
@@ -382,7 +382,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -596,7 +596,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = PPD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres, bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_AWAITING_EVIDENCE_RESPONDENT_B_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_AWAITING_EVIDENCE_RESPONDENT_B_JSON.ipynb
@@ -379,7 +379,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "#display(df)"
    ]
   },
@@ -592,7 +592,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = PPD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_CASE_UNDER_REVIEW_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_CASE_UNDER_REVIEW_JSON.ipynb
@@ -384,7 +384,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "#display(df)"
    ]
   },
@@ -650,7 +650,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = PPD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_A_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_A_JSON.ipynb
@@ -425,7 +425,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -791,7 +791,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = DA.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_B_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_B_JSON.ipynb
@@ -427,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -808,7 +808,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = DB.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_DECISION_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_DECISION_JSON.ipynb
@@ -428,7 +428,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -743,7 +743,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = D.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_ENDED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_ENDED_JSON.ipynb
@@ -427,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -801,7 +801,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = E.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_FTPA_DECIDED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_FTPA_DECIDED_JSON.ipynb
@@ -428,7 +428,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -780,7 +780,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = FTD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_A_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_A_JSON.ipynb
@@ -426,7 +426,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -778,7 +778,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = FSA.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_B_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_B_JSON.ipynb
@@ -427,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -779,7 +779,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = FSA.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_LISTING_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_LISTING_JSON.ipynb
@@ -424,7 +424,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -700,7 +700,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = L.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_PAYMENT_PENDING_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_PAYMENT_PENDING_JSON.ipynb
@@ -730,7 +730,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -973,7 +973,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = PP.paymentType(silver_m1)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = PP.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = PPD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_PREPARE_FOR_HEARING_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_PREPARE_FOR_HEARING_JSON.ipynb
@@ -430,7 +430,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "#display(df)"
    ]
   },
@@ -717,7 +717,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = L.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_REASON_FOR_APPEAL_SUBMITTED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_REASON_FOR_APPEAL_SUBMITTED_JSON.ipynb
@@ -386,7 +386,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -631,7 +631,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = PPD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_REMITTED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_REMITTED_JSON.ipynb
@@ -429,7 +429,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -803,7 +803,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PP.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = R.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/DQRules.py
@@ -36,7 +36,9 @@ def base_DQRules(state: str = "paymentPending"):
 
     checks = {}
 
-    state_flow = build_state_flow(state, [state])
+    # If paymentPending, add the detained state on top, otherwise assume it'll be added as part of the state flow.
+    base_flow = [state, "paymentPendingDetained"] if state == "paymentPending" else [state]
+    state_flow = build_state_flow(state, base_flow)
 
     # Add all checks in state, errors if state not in mapping.
     for state_to_process in state_flow:
@@ -71,8 +73,8 @@ def add_state_dq_rules(state: str) -> dict:
 
 def previous_state_map(state: str):
     previous_state = {
-        "paymentPending":                "paymentPendingDetained",
-        "appealSubmitted":               "paymentPending",
+        "paymentPendingDetained":        "paymentPending",
+        "appealSubmitted":               "paymentPendingDetained",
         "awaitingRespondentEvidence(a)": "appealSubmitted",
         "awaitingRespondentEvidence(b)": "awaitingRespondentEvidence(a)",
         "caseUnderReview":               "awaitingRespondentEvidence(b)",

--- a/Databricks/ACTIVE/APPEALS/shared_functions/appealSubmitted.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/appealSubmitted.py
@@ -16,6 +16,7 @@ from pyspark.sql.functions import (
 from pyspark.sql.types import ArrayType, IntegerType, StringType, StructField, StructType
 
 from . import paymentPending as PP
+from . import paymentPendingDetained as PPD
 
 
 ###############################################################
@@ -493,7 +494,7 @@ def remissionTypes(silver_m1, bronze_remission_lookup_df, silver_m4):
 #########          homeOffice extended              ###########
 ###############################################################
 def homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing):
-    df_final, df_audit = PP.homeOfficeDetails(
+    df_final, df_audit = PPD.homeOfficeDetails(
         silver_m1, silver_m2, silver_c, bronze_HORef_cleansing
     )
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpendingDetained_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpendingDetained_dq_rules.py
@@ -797,7 +797,8 @@ class paymentPendingDetainedDQRules(DQRulesBase):
             )"""
         )
 
-        # homeOfficeReferenceNumber: populated for detained/in-UK/non-GWF; '999999999' fallback for OOC+GWF.
+        # homeOfficeReferenceNumber: populated for detained/in-UK/non-GWF; for OOC+GWF it is
+        # null when a GWF reference was extracted, else '999999999' fallback (both refs null).
         checks["valid_homeOfficeReferenceNumber_not_null"] = (
             """(
                 (
@@ -810,7 +811,11 @@ class paymentPendingDetainedDQRules(DQRulesBase):
                     NOT dv_appellantIsInUk
                     AND Detained NOT IN (1,2,4)
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
-                    AND homeOfficeReferenceNumber = '999999999'
+                    AND (
+                        (gwfReferenceNumber IS NOT NULL AND homeOfficeReferenceNumber IS NULL)
+                        OR
+                        (gwfReferenceNumber IS NULL AND homeOfficeReferenceNumber = '999999999')
+                    )
                 )
             )"""
         )

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
@@ -719,7 +719,8 @@ class paymentPendingDQRules(DQRulesBase):
             )"""
         )
 
-        # homeOfficeReferenceNumber: populated for in-UK/non-GWF; '999999999' fallback for OOC+GWF.
+        # homeOfficeReferenceNumber: populated for in-UK/non-GWF; for OOC+GWF it is
+        # null when a GWF reference was extracted, else '999999999' fallback (both refs null).
         checks["valid_homeOfficeReferenceNumber_not_null"] = (
             """(
                 (
@@ -731,7 +732,11 @@ class paymentPendingDQRules(DQRulesBase):
                 (
                     NOT dv_appellantIsInUk
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
-                    AND homeOfficeReferenceNumber = '999999999'
+                    AND (
+                        (gwfReferenceNumber IS NOT NULL AND homeOfficeReferenceNumber IS NULL)
+                        OR
+                        (gwfReferenceNumber IS NULL AND homeOfficeReferenceNumber = '999999999')
+                    )
                 )
             )"""
         )

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -2106,7 +2106,7 @@ def homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing):
             home_office_decision_date_expr.alias("homeOfficeDecisionDate"),
             decision_letter_received_date_expr.alias("decisionLetterReceivedDate"),
             date_entry_clearance_decision_expr.alias("dateEntryClearanceDecision"),
-            when(home_office_reference_number_expr.isNull(), "999999999").otherwise(home_office_reference_number_expr).alias("homeOfficeReferenceNumber"),
+            when(home_office_reference_number_expr.isNull() & gwf_reference_number_expr.isNull(), "999999999").otherwise(home_office_reference_number_expr).alias("homeOfficeReferenceNumber"),
             gwf_reference_number_expr.alias("gwfReferenceNumber"),
             when(col("dv_CCDAppealType").isin("RP", "PA"), "Yes")
                         .otherwise(None)

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPendingDetained.py
@@ -635,7 +635,7 @@ def homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing):
         .withColumn("decisionLetterReceivedDate", decision_letter_received_date_expr)
         .withColumn("dateEntryClearanceDecision", date_entry_clearance_decision_expr)
         .withColumn("homeOfficeReferenceNumber",
-            when(home_office_reference_number_expr.isNull(), "999999999").otherwise(home_office_reference_number_expr))
+            when(home_office_reference_number_expr.isNull() & gwf_reference_number_expr.isNull(), "999999999").otherwise(home_office_reference_number_expr))  # if both HO and GWF Ref are NULL, set default for HO Ref Number.
         .withColumn("gwfReferenceNumber", gwf_reference_number_expr)
         .select("content.*", "homeOfficeDecisionDate", "decisionLetterReceivedDate",
                 "dateEntryClearanceDecision", "homeOfficeReferenceNumber", "gwfReferenceNumber")

--- a/tests/active/appealSubmitted/aps_homeOfficeDetails_test.py
+++ b/tests/active/appealSubmitted/aps_homeOfficeDetails_test.py
@@ -42,8 +42,8 @@ class TestAppealSubmittedHomeOfficeDetails:
         return case_no_df, case_no_df
 
     def test_homeOfficeSearchStatus_pa(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 2, appeal_type="PA")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 2, appeal_type="PA")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1", "2"], appeal_type="PA"),
@@ -56,8 +56,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert resultList[1][0] == "SUCCESS"
 
     def test_homeOfficeSearchStatus_rp(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="RP")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="RP")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1"], appeal_type="RP"),
@@ -67,8 +67,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert df.select("homeOfficeSearchStatus").collect()[0][0] == "SUCCESS"
 
     def test_homeOfficeSearchStatus_non_pa_rp(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="EA")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="EA")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1"], appeal_type="EA"),
@@ -78,8 +78,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert df.select("homeOfficeSearchStatus").collect()[0][0] is None
 
     def test_homeOfficeSearchNoMatch_pa(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 2, appeal_type="PA")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 2, appeal_type="PA")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1", "2"], appeal_type="PA"),
@@ -92,8 +92,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert resultList[1][0] == "NO_MATCH"
 
     def test_homeOfficeSearchNoMatch_non_pa_rp(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="HU")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="HU")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1"], appeal_type="HU"),
@@ -103,8 +103,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert df.select("homeOfficeSearchNoMatch").collect()[0][0] is None
 
     def test_matchingAppellantDetailsFound_pa(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 2, appeal_type="PA")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 2, appeal_type="PA")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1", "2"], appeal_type="PA"),
@@ -117,8 +117,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert resultList[1][0] == "No"
 
     def test_matchingAppellantDetailsFound_non_pa_rp(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="DC")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="DC")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1"], appeal_type="DC"),
@@ -128,8 +128,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert df.select("matchingAppellantDetailsFound").collect()[0][0] is None
 
     def test_homeOfficeAppellantsList_pa(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="PA")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="PA")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1"], appeal_type="PA"),
@@ -149,8 +149,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert result[0]["list_item_label"] == "No Match"
 
     def test_homeOfficeAppellantsList_non_pa_rp(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="EU")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="EU")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1"], appeal_type="EU"),
@@ -160,8 +160,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert df.select("homeOfficeAppellantsList").collect()[0][0] is None
 
     def test_homeOfficeCaseStatusData_pa(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="PA")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="PA")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1"], appeal_type="PA"),
@@ -199,8 +199,8 @@ class TestAppealSubmittedHomeOfficeDetails:
             assert result[0]["roleSubType_code"] == "No match"
 
     def test_homeOfficeCaseStatusData_non_pa_rp(self, spark):
-        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="EA")
+        with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PPD') as PPD:
+            PPD.homeOfficeDetails.return_value = self.pp_df(spark, 1, appeal_type="EA")
 
             df, df_audit = homeOfficeDetails(
                 self.silver_m1(spark, ["1"], appeal_type="EA"),

--- a/tests/active/paymentPending/homeOffice_test.py
+++ b/tests/active/paymentPending/homeOffice_test.py
@@ -132,7 +132,7 @@ def test_category_38_with_gwf_reference(homeOfficeDetails_outputs):
         homeOfficeDecisionDate=None,
         decisionLetterReceivedDate=None,
         dateEntryClearanceDecision="2022-06-30",
-        homeOfficeReferenceNumber="999999999",
+        homeOfficeReferenceNumber=None,
         gwfReferenceNumber="061121374",
     )
 
@@ -143,7 +143,7 @@ def test_category_38_with_gwf_reference_second_case(homeOfficeDetails_outputs):
         row,
         decisionLetterReceivedDate=None,
         dateEntryClearanceDecision="2020-02-15",
-        homeOfficeReferenceNumber="999999999",
+        homeOfficeReferenceNumber=None,
         gwfReferenceNumber="063622668",
     )
 

--- a/tests/active/paymentPendingDetained/homeOffice_test.py
+++ b/tests/active/paymentPendingDetained/homeOffice_test.py
@@ -221,14 +221,15 @@ def test_ooc_non_gwf_decision_letter_received_date(homeOfficeDetails_outputs):
 
 
 def test_ooc_gwf_date_entry_clearance_and_gwf_number(homeOfficeDetails_outputs):
-    """OOC, not detained, GWF ref → dateEntryClearanceDecision + gwfReferenceNumber populated."""
+    """OOC, not detained, GWF ref → dateEntryClearanceDecision + gwfReferenceNumber populated;
+    homeOfficeReferenceNumber is null since a GWF reference was successfully extracted."""
     row = homeOfficeDetails_outputs["HU/OOC/0002"]
     assert_equals(
         row,
         homeOfficeDecisionDate=None,
         decisionLetterReceivedDate=None,
         dateEntryClearanceDecision="2022-06-30",
-        homeOfficeReferenceNumber="999999999",
+        homeOfficeReferenceNumber=None,
     )
     assert row["gwfReferenceNumber"] is not None
     assert "GWF" not in row["gwfReferenceNumber"]  # cleaned — digits only


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ARIADM-2336

From clarification in ticket:
Only set homeOfficeReferenceNumber to the default 999999999 if also GWFReferenceNumber is not set.
It is mandatory for one of the two fields to be set, but currently homeOfficeReferenceNumber is always set.

Also fixes:

Issue where paymentPendingDetained homeOfficeDetails was not being passed into other states.
Issue where the state flow was adding the order of the detained DQ rules incorrectly, now the order is fixed.