### PR TITLE
Fix for GWF Prefix being removed

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1948,6 +1948,12 @@ def cleanReferenceNumber(ref):
     if ref is None or ref == '' or ref.strip().upper() == 'NULL':
         return None
 
+    stripped_ref = ref.strip()
+    if stripped_ref.upper().startswith("GWF"):
+        remainder = stripped_ref[3:]
+        cleaned_remainder = re.sub(r"\D", "", remainder)
+        return "GWF" + cleaned_remainder
+
     if len(ref) > 9 and len(ref) < 16:
         no_letters = re.sub(r"[a-zA-Z]", "", ref)
         parts = no_letters.rsplit("/", 1)
@@ -1964,7 +1970,7 @@ def cleanReferenceNumber(ref):
         digits_only = re.sub(r"\D", "", combined)
         return digits_only.rjust(9, '0')
 
-    if len(ref) < 9 and not ('GWF' in ref or 'HO' in ref):
+    if len(ref) < 9:
         digits_only = re.sub(r"\D", "", ref)
         return digits_only.rjust(9, '0')
     

--- a/tests/active/paymentPending/homeOffice_test.py
+++ b/tests/active/paymentPending/homeOffice_test.py
@@ -133,7 +133,7 @@ def test_category_38_with_gwf_reference(homeOfficeDetails_outputs):
         decisionLetterReceivedDate=None,
         dateEntryClearanceDecision="2022-06-30",
         homeOfficeReferenceNumber=None,
-        gwfReferenceNumber="061121374",
+        gwfReferenceNumber="GWF061121374",
     )
 
 def test_category_38_with_gwf_reference_second_case(homeOfficeDetails_outputs):
@@ -144,7 +144,7 @@ def test_category_38_with_gwf_reference_second_case(homeOfficeDetails_outputs):
         decisionLetterReceivedDate=None,
         dateEntryClearanceDecision="2020-02-15",
         homeOfficeReferenceNumber=None,
-        gwfReferenceNumber="063622668",
+        gwfReferenceNumber="GWF063622668",
     )
 
 def test_category_38_without_gwf_reference(homeOfficeDetails_outputs):

--- a/tests/active/paymentPendingDetained/homeOffice_test.py
+++ b/tests/active/paymentPendingDetained/homeOffice_test.py
@@ -231,8 +231,8 @@ def test_ooc_gwf_date_entry_clearance_and_gwf_number(homeOfficeDetails_outputs):
         dateEntryClearanceDecision="2022-06-30",
         homeOfficeReferenceNumber=None,
     )
-    assert row["gwfReferenceNumber"] is not None
-    assert "GWF" not in row["gwfReferenceNumber"]  # cleaned — digits only
+    # GWF prefix is preserved by cleanReferenceNumber; only non-digit noise is stripped
+    assert row["gwfReferenceNumber"] == "GWF063622999"
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
When prefixed with GWF, return cleaned directly