### PR TITLE
Fix all Nullable DQ rules

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/appealSubmitted_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/appealSubmitted_dq_rules.py
@@ -254,7 +254,7 @@ class appealSubmittedDQRules(DQRulesBase):
                     (
                         (
                             (
-                                PaymentRemissionGranted = 1
+                                PaymentRemissionGranted <=> 1
                                 OR (
                                     (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
                                     AND COALESCE(SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 5)), 0) > 0
@@ -265,7 +265,7 @@ class appealSubmittedDQRules(DQRulesBase):
                         OR
                         (
                             (
-                                PaymentRemissionGranted = 2
+                                PaymentRemissionGranted <=> 2
                                 OR (
                                     (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
                                     AND COALESCE(SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 5)), 0) = 0
@@ -291,7 +291,7 @@ class appealSubmittedDQRules(DQRulesBase):
                     (
                         (
                             (
-                                PaymentRemissionGranted = 1
+                                PaymentRemissionGranted <=> 1
                                 OR (
                                     (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
                                     AND COALESCE(SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 5)), 0) > 0
@@ -302,7 +302,7 @@ class appealSubmittedDQRules(DQRulesBase):
                         OR
                         (
                             (
-                                PaymentRemissionGranted = 2
+                                PaymentRemissionGranted <=> 2
                                 OR (
                                     (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
                                     AND COALESCE(SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 5)), 0) = 0

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/awaitingEvidenceRespondentA_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/awaitingEvidenceRespondentA_dq_rules.py
@@ -13,6 +13,6 @@ class awaitingEvidenceRespondentADQRules(DQRulesBase):
 
         checks["valid_directions"] = "(directions IS NOT NULL)"
 
-        checks["valid_uploadHomeOfficeBundleAvailable"] = "(uploadHomeOfficeBundleAvailable IN ('Yes','No'))"
+        checks["valid_uploadHomeOfficeBundleAvailable"] = "(uploadHomeOfficeBundleAvailable IS NOT NULL AND uploadHomeOfficeBundleAvailable IN ('Yes','No'))"
 
         return checks

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
@@ -17,28 +17,16 @@ class decidedADQRules(DQRulesBase):
         checks["valid_actualCaseHearingLength"] = ("""
                 (
                     (
-                        CaseStatus_SD IN (37,38,26)
-                        AND Outcome_SD IN (1,2)
-                        AND element_at(actualCaseHearingLength, 'hours') =
+                        CaseStatus_SD IS NOT NULL AND CaseStatus_SD IN (37,38,26)
+                        AND Outcome_SD IS NOT NULL AND Outcome_SD IN (1,2)
+                        AND element_at(actualCaseHearingLength, 'hours') <=>
                             CAST(FLOOR(CAST(HearingDuration AS INT) / 60) AS STRING)
-                        AND element_at(actualCaseHearingLength, 'minutes') =
+                        AND element_at(actualCaseHearingLength, 'minutes') <=>
                             CAST(CAST(HearingDuration AS INT) % 60 AS STRING)
                     )
                     OR
                     (
-                        (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
-                        AND element_at(actualCaseHearingLength, 'hours') IS NULL
-                        AND element_at(actualCaseHearingLength, 'minutes') IS NULL
-                    )
-                    OR
-                    (
-                        (CaseStatus_SD IS NOT NULL OR Outcome_SD IS NULL)
-                        AND element_at(actualCaseHearingLength, 'hours') IS NULL
-                        AND element_at(actualCaseHearingLength, 'minutes') IS NULL
-                    )
-                    OR
-                    (
-                        hearingDuration IS NULL
+                        (CaseStatus_SD IS NULL OR CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD IS NULL OR Outcome_SD NOT IN (1,2))
                         AND element_at(actualCaseHearingLength, 'hours') IS NULL
                         AND element_at(actualCaseHearingLength, 'minutes') IS NULL
                     )
@@ -49,7 +37,7 @@ class decidedADQRules(DQRulesBase):
             """
             (   (attendingJudge IS NULL AND Adj_Determination_Title IS NULL AND Adj_Determination_Forenames IS NULL AND Adj_Determination_Surname IS NULL)
                 OR
-                (attendingJudge = concat(Adj_Determination_Title, ' ', Adj_Determination_Forenames, ' ', Adj_Determination_Surname))
+                (attendingJudge IS NOT NULL AND attendingJudge <=> concat(Adj_Determination_Title, ' ', Adj_Determination_Forenames, ' ', Adj_Determination_Surname))
             )
             """
         )
@@ -61,21 +49,17 @@ class decidedADQRules(DQRulesBase):
         checks["valid_sendDecisionsAndReasonsDate"] = """
         (
             (
-                CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-                AND 
+                CaseStatus_SD IS NOT NULL AND CaseStatus_SD IN (37,38,26)
+                AND Outcome_SD IS NOT NULL AND Outcome_SD IN (1,2)
+                AND
                 to_date(
                     to_timestamp(DecisionDate_decided, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX')
-                ) = to_date(trim(sendDecisionsAndReasonsDate), 'yyyy-MM-dd')
+                ) <=> to_date(trim(sendDecisionsAndReasonsDate), 'yyyy-MM-dd')
             )
             OR
             (
-                (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
-                AND appealDate IS NULL
-            )
-            OR
-            (
-                (CaseStatus_SD IS NULL OR Outcome_SD IS NULL)
-                AND appealDate IS NULL
+                (CaseStatus_SD IS NULL OR CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD IS NULL OR Outcome_SD NOT IN (1,2))
+                AND sendDecisionsAndReasonsDate IS NULL
             )
         )
         """
@@ -83,43 +67,35 @@ class decidedADQRules(DQRulesBase):
         checks["valid_appealDate"] = """
         (
             (
-                CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-                AND 
-                to_date(DecisionDate_decided, 'yyyy-MM-dd') = to_date(appealDate, 'yyyy-MM-dd')
+                CaseStatus_SD IS NOT NULL AND CaseStatus_SD IN (37,38,26)
+                AND Outcome_SD IS NOT NULL AND Outcome_SD IN (1,2)
+                AND
+                to_date(DecisionDate_decided, 'yyyy-MM-dd') <=> to_date(appealDate, 'yyyy-MM-dd')
             )
             OR
             (
-                (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
-                AND appealDate IS NULL
-            )
-            OR
-            (
-                (CaseStatus_SD IS NULL OR Outcome_SD IS NULL)
+                (CaseStatus_SD IS NULL OR CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD IS NULL OR Outcome_SD NOT IN (1,2))
                 AND appealDate IS NULL
             )
         )
         """
 
-        checks["valid_anonymityOrder"] = ("(anonymityOrder = 'No')")
+        checks["valid_anonymityOrder"] = ("(anonymityOrder <=> 'No')")
 
         checks["valid_appealDecision"] = """
         (
             (
-                CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-                AND 
+                CaseStatus_SD IS NOT NULL AND CaseStatus_SD IN (37,38,26)
+                AND Outcome_SD IS NOT NULL AND Outcome_SD IN (1,2)
+                AND
                 CASE
-                    WHEN Outcome_SD = 1 THEN (appealDecision = 'Allowed')
-                    WHEN Outcome_SD = 2 THEN (appealDecision = 'Dismissed')
+                    WHEN Outcome_SD = 1 THEN (appealDecision <=> 'Allowed')
+                    WHEN Outcome_SD = 2 THEN (appealDecision <=> 'Dismissed')
                 END
             )
             OR
             (
-                (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
-                AND appealDecision IS NULL
-            )
-            OR
-            (
-                (CaseStatus_SD IS NULL OR Outcome_SD IS NULL)
+                (CaseStatus_SD IS NULL OR CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD IS NULL OR Outcome_SD NOT IN (1,2))
                 AND appealDecision IS NULL
             )
         )
@@ -128,22 +104,18 @@ class decidedADQRules(DQRulesBase):
         checks["valid_isDecisionAllowed"] = """
         (
             (
-                CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-                AND 
+                CaseStatus_SD IS NOT NULL AND CaseStatus_SD IN (37,38,26)
+                AND Outcome_SD IS NOT NULL AND Outcome_SD IN (1,2)
+                AND
                 CASE
-                    WHEN Outcome_SD = 1 THEN (isDecisionAllowed = 'allowed')
-                    WHEN Outcome_SD = 2 THEN (isDecisionAllowed = 'dismissed')
+                    WHEN Outcome_SD = 1 THEN (isDecisionAllowed <=> 'allowed')
+                    WHEN Outcome_SD = 2 THEN (isDecisionAllowed <=> 'dismissed')
                     ELSE (isDecisionAllowed IS NULL)
                 END
             )
             OR
             (
-                (CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD NOT IN (1,2))
-                AND isDecisionAllowed IS NULL
-            )
-            OR
-            (
-                (CaseStatus_SD IS NULL OR Outcome_SD IS NULL)
+                (CaseStatus_SD IS NULL OR CaseStatus_SD NOT IN (37,38,26) OR Outcome_SD IS NULL OR Outcome_SD NOT IN (1,2))
                 AND isDecisionAllowed IS NULL
             )
         )
@@ -159,7 +131,7 @@ class decidedADQRules(DQRulesBase):
 
     def get_checks_general_default(self, checks={}):
 
-        checks["valid_appealDecisionAvailable"] = ("(appealDecisionAvailable = 'Yes')")
+        checks["valid_appealDecisionAvailable"] = ("(appealDecisionAvailable <=> 'Yes')")
 
         return checks
 
@@ -172,11 +144,11 @@ class decidedADQRules(DQRulesBase):
                     THEN ftpaApplicationDeadline IS NULL
 
                 WHEN Detained IN (1,2,4) OR dv_appellantIsInUk_ftpa = true
-                    THEN to_date(ftpaApplicationDeadline) =
+                    THEN to_date(ftpaApplicationDeadline) <=>
                         date_add(to_date(DecisionDate_ftpa_decideda), 14)
 
                 WHEN dv_appellantIsInUk_ftpa = false
-                    THEN to_date(ftpaApplicationDeadline) =
+                    THEN to_date(ftpaApplicationDeadline) <=>
                         date_add(to_date(DecisionDate_ftpa_decideda), 28)
 
                 ELSE ftpaApplicationDeadline IS NULL

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_a_dq_rules.py
@@ -54,6 +54,9 @@ class decidedADQRules(DQRulesBase):
                 AND
                 to_date(
                     to_timestamp(DecisionDate_decided, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX')
+                ) IS NOT NULL
+                AND to_date(
+                    to_timestamp(DecisionDate_decided, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX')
                 ) <=> to_date(trim(sendDecisionsAndReasonsDate), 'yyyy-MM-dd')
             )
             OR
@@ -70,7 +73,8 @@ class decidedADQRules(DQRulesBase):
                 CaseStatus_SD IS NOT NULL AND CaseStatus_SD IN (37,38,26)
                 AND Outcome_SD IS NOT NULL AND Outcome_SD IN (1,2)
                 AND
-                to_date(DecisionDate_decided, 'yyyy-MM-dd') <=> to_date(appealDate, 'yyyy-MM-dd')
+                to_date(DecisionDate_decided, 'yyyy-MM-dd') IS NOT NULL
+                AND to_date(DecisionDate_decided, 'yyyy-MM-dd') <=> to_date(appealDate, 'yyyy-MM-dd')
             )
             OR
             (

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_b_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_b_dq_rules.py
@@ -15,20 +15,22 @@ class decidedBDQRules(DQRulesBase):
     def get_checks_document(self, checks={}):
 
         checks["valid_allSetAsideDocs"] = """(
-            size(allSetAsideDocs) = 0
+            COALESCE(size(allSetAsideDocs), 0) = 0
         )"""
 
         checks["valid_allFtpaAppellantDecisionDocs"] = """(
             CASE
-                WHEN Party = 1 AND CaseStatus_decb = 39 THEN size(allFtpaAppellantDecisionDocs) = 0
+                WHEN Party = 1 AND CaseStatus_decb = 39 THEN COALESCE(size(allFtpaAppellantDecisionDocs), 0) = 0
                 WHEN Party = 2 AND CaseStatus_decb = 39 THEN allFtpaAppellantDecisionDocs IS NULL
+                ELSE FALSE
             END
         )"""
 
         checks["valid_allFtpaRespondentDecisionDocs"] = """(
             CASE
-                WHEN Party = 2 AND CaseStatus_decb = 39 THEN size(allFtpaRespondentDecisionDocs) = 0
+                WHEN Party = 2 AND CaseStatus_decb = 39 THEN COALESCE(size(allFtpaRespondentDecisionDocs), 0) = 0
                 WHEN Party = 1 AND CaseStatus_decb = 39 THEN allFtpaRespondentDecisionDocs IS NULL
+                ELSE FALSE
             END
         )"""
 
@@ -37,10 +39,10 @@ class decidedBDQRules(DQRulesBase):
 
     def get_checks_general_default(self, checks={}):
 
-        checks["valid_isDlrmSetAsideEnabled"] = ("(isDlrmSetAsideEnabled = 'Yes')")
-        checks["valid_isReheardAppealEnabled"] = ("(isReheardAppealEnabled = 'Yes')")
-        checks["valid_secondFtpaDecisionExists"] = ("(secondFtpaDecisionExists = 'No')")
-        checks["valid_caseFlagSetAsideReheardExists"] = ("(caseFlagSetAsideReheardExists = 'Yes')")
+        checks["valid_isDlrmSetAsideEnabled"] = ("(isDlrmSetAsideEnabled <=> 'Yes')")
+        checks["valid_isReheardAppealEnabled"] = ("(isReheardAppealEnabled <=> 'Yes')")
+        checks["valid_secondFtpaDecisionExists"] = ("(secondFtpaDecisionExists <=> 'No')")
+        checks["valid_caseFlagSetAsideReheardExists"] = ("(caseFlagSetAsideReheardExists <=> 'Yes')")
 
         return checks
 
@@ -49,15 +51,17 @@ class decidedBDQRules(DQRulesBase):
 
         checks["valid_isFtpaAppellantDecided"] = """(
             CASE
-                WHEN Party = 1 AND CaseStatus_decb = 39 THEN isFtpaAppellantDecided = 'Yes'
+                WHEN Party = 1 AND CaseStatus_decb = 39 THEN isFtpaAppellantDecided <=> 'Yes'
                 WHEN Party = 2 AND CaseStatus_decb = 39  THEN isFtpaAppellantDecided IS NULL
+                ELSE FALSE
             END
         )"""
 
         checks["valid_isFtpaRespondentDecided"] = """(
             CASE
-                WHEN Party = 2 AND CaseStatus_decb = 39 THEN isFtpaRespondentDecided = 'Yes'
+                WHEN Party = 2 AND CaseStatus_decb = 39 THEN isFtpaRespondentDecided <=> 'Yes'
                 WHEN Party = 1 AND CaseStatus_decb = 39 THEN isFtpaRespondentDecided IS NULL
+                ELSE FALSE
             END
         )"""
 
@@ -71,55 +75,58 @@ class decidedBDQRules(DQRulesBase):
         WHEN Party = 1 AND CaseStatus_decb = 39 THEN
             ftpaList IS NOT NULL
         AND size(ftpaList) = 1
-        AND element_at(ftpaList, 1).id = '1'
-        AND lower(element_at(ftpaList, 1).value.ftpaApplicant) = 'appellant'
+        AND element_at(ftpaList, 1).id <=> '1'
+        AND lower(element_at(ftpaList, 1).value.ftpaApplicant) <=> 'appellant'
         AND element_at(ftpaList, 1).value.ftpaDecisionDate <=> ftpaAppellantDecisionDate
         AND element_at(ftpaList, 1).value.ftpaApplicationDate <=> ftpaAppellantDecisionDate
-        AND size(element_at(ftpaList, 1).value.ftpaGroundsDocuments) = 0
-        AND size(element_at(ftpaList, 1).value.ftpaEvidenceDocuments) = 0
-        AND element_at(ftpaList, 1).value.ftpaDecisionOutcomeType = "remadeRule32"
-        AND element_at(ftpaList, 1).value.ftpaAppellantGroundsText = ""
-        AND element_at(ftpaList, 1).value.ftpaDecisionRemadeRule32Text = "This is an ARIA Migrated case. Please refer to the documents for the notice to set aside."
-        AND element_at(ftpaList, 1).value.isFtpaNoticeOfDecisionSetAside = "No"
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaGroundsDocuments), 0) = 0
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaEvidenceDocuments), 0) = 0
+        AND element_at(ftpaList, 1).value.ftpaDecisionOutcomeType <=> "remadeRule32"
+        AND element_at(ftpaList, 1).value.ftpaAppellantGroundsText <=> ""
+        AND element_at(ftpaList, 1).value.ftpaDecisionRemadeRule32Text <=> "This is an ARIA Migrated case. Please refer to the documents for the notice to set aside."
+        AND element_at(ftpaList, 1).value.isFtpaNoticeOfDecisionSetAside <=> "No"
 
         WHEN Party = 2 AND CaseStatus_decb = 39 THEN
             ftpaList IS NOT NULL
         AND size(ftpaList) = 1
-        AND element_at(ftpaList, 1).id = '1'
-        AND lower(element_at(ftpaList, 1).value.ftpaApplicant) = 'respondent'
+        AND element_at(ftpaList, 1).id <=> '1'
+        AND lower(element_at(ftpaList, 1).value.ftpaApplicant) <=> 'respondent'
         AND element_at(ftpaList, 1).value.ftpaDecisionDate <=> ftpaRespondentDecisionDate
         AND element_at(ftpaList, 1).value.ftpaApplicationDate <=> ftpaRespondentDecisionDate
-        AND size(element_at(ftpaList, 1).value.ftpaGroundsDocuments) = 0
-        AND size(element_at(ftpaList, 1).value.ftpaEvidenceDocuments) = 0
-        AND element_at(ftpaList, 1).value.ftpaDecisionOutcomeType = "remadeRule32"
-        AND element_at(ftpaList, 1).value.ftpaAppellantGroundsText = ""
-        AND element_at(ftpaList, 1).value.ftpaDecisionRemadeRule32Text = "This is an ARIA Migrated case. Please refer to the documents for the notice to set aside."
-        AND element_at(ftpaList, 1).value.isFtpaNoticeOfDecisionSetAside = "No"
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaGroundsDocuments), 0) = 0
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaEvidenceDocuments), 0) = 0
+        AND element_at(ftpaList, 1).value.ftpaDecisionOutcomeType <=> "remadeRule32"
+        AND element_at(ftpaList, 1).value.ftpaAppellantGroundsText <=> ""
+        AND element_at(ftpaList, 1).value.ftpaDecisionRemadeRule32Text <=> "This is an ARIA Migrated case. Please refer to the documents for the notice to set aside."
+        AND element_at(ftpaList, 1).value.isFtpaNoticeOfDecisionSetAside <=> "No"
+        ELSE FALSE
         END
         )
         """
 
         checks["valid_ftpaApplicantType"] = """(
-            
-            CaseStatus_decb = 39 
-            AND 
+
+            CaseStatus_decb <=> 39
+            AND
             CASE
-                WHEN Party = 1 and CaseStatus_decb = 39 THEN ftpaApplicantType = 'appellant'
-                WHEN Party = 2 and CaseStatus_decb = 39 THEN ftpaApplicantType = 'respondent'
+                WHEN Party = 1 and CaseStatus_decb = 39 THEN ftpaApplicantType <=> 'appellant'
+                WHEN Party = 2 and CaseStatus_decb = 39 THEN ftpaApplicantType <=> 'respondent'
+                ELSE FALSE
             END
         )"""
 
         checks["valid_ftpaFirstDecision"] = """(
-            
-            ftpaFirstDecision = 'remadeRule32'
+
+            ftpaFirstDecision <=> 'remadeRule32'
 
         )"""
 
         checks["valid_ftpaAppellantDecisionDate"] = """(
 
             CASE
-                WHEN Party = 1 and CaseStatus_decb = 39 THEN ftpaAppellantDecisionDate = date_format(DecisionDate_ftpa,'yyyy-MM-dd')
+                WHEN Party = 1 and CaseStatus_decb = 39 THEN ftpaAppellantDecisionDate <=> date_format(DecisionDate_ftpa,'yyyy-MM-dd')
                 WHEN Party = 2 and CaseStatus_decb = 39 THEN ftpaAppellantDecisionDate IS NULL
+                ELSE FALSE
             END
         )"""
 
@@ -128,28 +135,31 @@ class decidedBDQRules(DQRulesBase):
             CASE
                 WHEN Party = 2 and CaseStatus_decb = 39 THEN ftpaRespondentDecisionDate <=> date_format(DecisionDate_ftpa,'yyyy-MM-dd')
                 WHEN Party = 1 and CaseStatus_decb = 39 THEN ftpaRespondentDecisionDate IS NULL
+                ELSE FALSE
             END
         )"""
 
         checks["valid_ftpaFinalDecisionForDisplay"] = """(
-            
-            ftpaFinalDecisionForDisplay = 'undecided'
+
+            ftpaFinalDecisionForDisplay <=> 'undecided'
 
         )"""
 
         checks["valid_ftpaAppellantRjDecisionOutcomeType"] = """(
 
             CASE
-                WHEN Party = 1 and CaseStatus_decb = 39 THEN ftpaAppellantRjDecisionOutcomeType = 'remadeRule32'
+                WHEN Party = 1 and CaseStatus_decb = 39 THEN ftpaAppellantRjDecisionOutcomeType <=> 'remadeRule32'
                 WHEN Party = 2 and CaseStatus_decb = 39 THEN ftpaAppellantRjDecisionOutcomeType IS NULL
+                ELSE FALSE
             END
         )"""
 
         checks["valid_ftpaRespondentRjDecisionOutcomeType"] = """(
 
             CASE
-                WHEN Party = 2 and CaseStatus_decb = 39 THEN ftpaRespondentRjDecisionOutcomeType = 'remadeRule32'
+                WHEN Party = 2 and CaseStatus_decb = 39 THEN ftpaRespondentRjDecisionOutcomeType <=> 'remadeRule32'
                 WHEN Party = 1 and CaseStatus_decb = 39 THEN ftpaRespondentRjDecisionOutcomeType IS NULL
+                ELSE FALSE
             END
         )"""
 
@@ -159,33 +169,33 @@ class decidedBDQRules(DQRulesBase):
     def get_checks_set_aside(self, checks={}):
 
         checks["valid_reasonRehearingRule32"] = """(
-            
-            reasonRehearingRule32 = 'Set aside and to be reheard under rule 32'
-            
+
+            reasonRehearingRule32 <=> 'Set aside and to be reheard under rule 32'
+
         )"""
 
         checks["valid_rule32ListingAdditionalIns"] = """(
-            
-            rule32ListingAdditionalIns = 'This is an ARIA Migrated case. Please refer to the documents for any additional listing instructions.'
-            
+
+            rule32ListingAdditionalIns <=> 'This is an ARIA Migrated case. Please refer to the documents for any additional listing instructions.'
+
         )"""
 
         checks["valid_updateTribunalDecisionList"] = """(
-            
-            updateTribunalDecisionList = 'underRule32'
-            
+
+            updateTribunalDecisionList <=> 'underRule32'
+
         )"""
 
         checks["valid_ftpaFinalDecisionRemadeRule32"] = """(
-            
-            ftpaFinalDecisionRemadeRule32 = ''
-            
+
+            ftpaFinalDecisionRemadeRule32 <=> ''
+
         )"""
 
         checks["valid_updateTribunalDecisionDateRule32"] = """(
-            
-            updateTribunalDecisionDateRule32 = date_format(DecisionDate_decb,'yyyy-MM-dd') 
-            
+
+            updateTribunalDecisionDateRule32 <=> date_format(DecisionDate_decb,'yyyy-MM-dd')
+
         )"""
 
 
@@ -200,15 +210,17 @@ class decidedBDQRules(DQRulesBase):
 
         checks["valid_ftpaAppellantDecisionRemadeRule32Text"] = """(
             CASE
-                WHEN Party = 1 AND CaseStatus_decb = 39 THEN ftpaAppellantDecisionRemadeRule32Text = 'This is an ARIA Migrated case. Please refer to the documents for the notice to set aside.'
+                WHEN Party = 1 AND CaseStatus_decb = 39 THEN ftpaAppellantDecisionRemadeRule32Text <=> 'This is an ARIA Migrated case. Please refer to the documents for the notice to set aside.'
                 WHEN Party = 2 AND CaseStatus_decb = 39 THEN ftpaAppellantDecisionRemadeRule32Text IS NULL
+                ELSE FALSE
             END
         )"""
 
         checks["valid_ftpaRespondentDecisionRemadeRule32Text"] = """(
             CASE
-                WHEN Party = 2 AND CaseStatus_decb = 39 THEN ftpaRespondentDecisionRemadeRule32Text = 'This is an ARIA Migrated case. Please refer to the documents for the notice to set aside.'
+                WHEN Party = 2 AND CaseStatus_decb = 39 THEN ftpaRespondentDecisionRemadeRule32Text <=> 'This is an ARIA Migrated case. Please refer to the documents for the notice to set aside.'
                 WHEN Party = 1 AND CaseStatus_decb = 39 THEN ftpaRespondentDecisionRemadeRule32Text IS NULL
+                ELSE FALSE
             END
         )"""
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_b_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decided_b_dq_rules.py
@@ -124,7 +124,7 @@ class decidedBDQRules(DQRulesBase):
         checks["valid_ftpaAppellantDecisionDate"] = """(
 
             CASE
-                WHEN Party = 1 and CaseStatus_decb = 39 THEN ftpaAppellantDecisionDate <=> date_format(DecisionDate_ftpa,'yyyy-MM-dd')
+                WHEN Party = 1 and CaseStatus_decb = 39 THEN date_format(DecisionDate_ftpa,'yyyy-MM-dd') IS NOT NULL AND ftpaAppellantDecisionDate <=> date_format(DecisionDate_ftpa,'yyyy-MM-dd')
                 WHEN Party = 2 and CaseStatus_decb = 39 THEN ftpaAppellantDecisionDate IS NULL
                 ELSE FALSE
             END
@@ -194,7 +194,8 @@ class decidedBDQRules(DQRulesBase):
 
         checks["valid_updateTribunalDecisionDateRule32"] = """(
 
-            updateTribunalDecisionDateRule32 <=> date_format(DecisionDate_decb,'yyyy-MM-dd')
+            date_format(DecisionDate_decb,'yyyy-MM-dd') IS NOT NULL
+            AND updateTribunalDecisionDateRule32 <=> date_format(DecisionDate_decb,'yyyy-MM-dd')
 
         )"""
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decision_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/decision_dq_rules.py
@@ -48,31 +48,31 @@ class decisionDQRules(DQRulesBase):
     def get_checks_document(self, checks={}):
         
         checks["valid_caseBundles"] = (
-            "(size(caseBundles) = 0) "
+            "(COALESCE(size(caseBundles), 0) = 0) "
         )
         return checks
 
     def get_checks_substantive_decision(self, checks={}):
 
-        checks["valid_scheduleOfIssuesAgreement"] = ("(scheduleOfIssuesAgreement = 'No')")
+        checks["valid_scheduleOfIssuesAgreement"] = ("(scheduleOfIssuesAgreement <=> 'No')")
 
-        checks["valid_scheduleOfIssuesDisagreementDescription"] = ("(scheduleOfIssuesDisagreementDescription = 'This is a migrated ARIA case. Please see the documents for information on the schedule of issues.')")
+        checks["valid_scheduleOfIssuesDisagreementDescription"] = ("(scheduleOfIssuesDisagreementDescription <=> 'This is a migrated ARIA case. Please see the documents for information on the schedule of issues.')")
 
-        checks["valid_immigrationHistoryAgreement"] = ("(immigrationHistoryAgreement = 'No')")
+        checks["valid_immigrationHistoryAgreement"] = ("(immigrationHistoryAgreement <=> 'No')")
 
-        checks["valid_immigrationHistoryDisagreementDescription"] = ("(immigrationHistoryDisagreementDescription = 'This is a migrated ARIA case. Please see the documents for information on the immigration history.')")
+        checks["valid_immigrationHistoryDisagreementDescription"] = ("(immigrationHistoryDisagreementDescription <=> 'This is a migrated ARIA case. Please see the documents for information on the immigration history.')")
 
         return checks
 
     def get_checks_general_default(self, checks={}):
 
-        checks["valid_hmcts"] = ("(hmcts = '[userImage:hmcts.png]')")
+        checks["valid_hmcts"] = ("(hmcts <=> '[userImage:hmcts.png]')")
 
-        checks["valid_stitchingStatus"] = ("(stitchingStatus = 'DONE')")
+        checks["valid_stitchingStatus"] = ("(stitchingStatus <=> 'DONE')")
 
-        checks["valid_bundleConfiguration"] = ("(bundleConfiguration = 'iac-hearing-bundle-config.yaml')")
+        checks["valid_bundleConfiguration"] = ("(bundleConfiguration <=> 'iac-hearing-bundle-config.yaml')")
 
-        checks["valid_decisionAndReasonsAvailable"] = ("(decisionAndReasonsAvailable = 'No')")
+        checks["valid_decisionAndReasonsAvailable"] = ("(decisionAndReasonsAvailable <=> 'No')")
 
         return checks
 
@@ -81,7 +81,7 @@ class decisionDQRules(DQRulesBase):
         checks["valid_bundleFileNamePrefix"] = (
             """
             (
-                bundleFileNamePrefix = replace(CaseNo, '/', ' ') || '-' || Appellant_Name AND bundleFileNamePrefix IS NOT NULL AND bundleFileNamePrefix != ""
+                bundleFileNamePrefix <=> replace(CaseNo, '/', ' ') || '-' || Appellant_Name AND bundleFileNamePrefix IS NOT NULL AND bundleFileNamePrefix != ""
             )
             """
         )

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ended_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ended_dq_rules.py
@@ -24,173 +24,179 @@ class endedDQRules(DQRulesBase):
 
         checks["valid_endAppealOutcome"] = """(
             (
-                (CaseStatus_end = 10 AND Outcome_end IN (80,122,25,120,2,105,13))
+                (CaseStatus_end <=> 10 AND Outcome_end IS NOT NULL AND Outcome_end IN (80,122,25,120,2,105,13))
                 OR
-                (CaseStatus_end = 46 AND Outcome_end = 31)
+                (CaseStatus_end <=> 46 AND Outcome_end <=> 31)
                 OR
-                (CaseStatus_end = 26 AND Outcome_end IN (80,13,25))
+                (CaseStatus_end <=> 26 AND Outcome_end IS NOT NULL AND Outcome_end IN (80,13,25))
                 OR
-                (CaseStatus_end IN (37,38) AND Outcome_end IN (80,13,25,72,125))
+                (CaseStatus_end IS NOT NULL AND CaseStatus_end IN (37,38) AND Outcome_end IS NOT NULL AND Outcome_end IN (80,13,25,72,125))
                 OR
-                (CaseStatus_end = 39 AND Outcome_end = 25)
+                (CaseStatus_end <=> 39 AND Outcome_end <=> 25)
                 OR
-                (CaseStatus_end = 51 AND Outcome_end IN (0,94,93))
+                (CaseStatus_end <=> 51 AND Outcome_end IS NOT NULL AND Outcome_end IN (0,94,93))
                 OR
-                (CaseStatus_end = 52 AND Outcome_end IN (91,95))
+                (CaseStatus_end <=> 52 AND Outcome_end IS NOT NULL AND Outcome_end IN (91,95))
                 OR
-                (CaseStatus_end = 36 AND Outcome_end IN (1,2,25))
+                (CaseStatus_end <=> 36 AND Outcome_end IS NOT NULL AND Outcome_end IN (1,2,25))
             )
 
             AND
 
             CASE
-                WHEN CaseStatus_end in(37,38,10,26) AND Outcome_end = 80 THEN endAppealOutcome = "Abandoned"
-                WHEN CaseStatus_end in(10) AND Outcome_end = 122 THEN endAppealOutcome = "Abandoned"
-                WHEN CaseStatus_end in(38) AND Outcome_end = 72 THEN endAppealOutcome = "Abandoned"
-                WHEN CaseStatus_end in(37,38) AND Outcome_end in (125) THEN endAppealOutcome = "Struck out"
+                WHEN CaseStatus_end in(37,38,10,26) AND Outcome_end = 80 THEN endAppealOutcome <=> "Abandoned"
+                WHEN CaseStatus_end in(10) AND Outcome_end = 122 THEN endAppealOutcome <=> "Abandoned"
+                WHEN CaseStatus_end in(38) AND Outcome_end = 72 THEN endAppealOutcome <=> "Abandoned"
+                WHEN CaseStatus_end in(37,38) AND Outcome_end in (125) THEN endAppealOutcome <=> "Struck out"
 
-                WHEN CaseStatus_end in(10,37,38,26) AND Outcome_end = 13 THEN endAppealOutcome = "No valid appeal"
+                WHEN CaseStatus_end in(10,37,38,26) AND Outcome_end = 13 THEN endAppealOutcome <=> "No valid appeal"
 
-                WHEN CaseStatus_end in(37,38,39,10,26) AND Outcome_end = 25 THEN endAppealOutcome = "Withdrawn"
+                WHEN CaseStatus_end in(37,38,39,10,26) AND Outcome_end = 25 THEN endAppealOutcome <=> "Withdrawn"
 
-                WHEN CaseStatus_end in(52) AND Outcome_end in (91,95) THEN endAppealOutcome = "Struck out"
-                WHEN CaseStatus_end in(51) AND Outcome_end in (93,94) THEN endAppealOutcome = "Struck out"
-                WHEN CaseStatus_end in(10) AND Outcome_end in (2,120) THEN endAppealOutcome = "Struck out"
-                WHEN CaseStatus_end in(46) AND Outcome_end in (31) THEN endAppealOutcome = "Struck out"
-                WHEN CaseStatus_end in(10) AND Outcome_end in (105) THEN endAppealOutcome = "Struck out"
-                WHEN CaseStatus_end in(36) AND Outcome_end in (1,2) THEN endAppealOutcome = "Struck out"
-                WHEN CaseStatus_end in(36) AND Outcome_end in (25) THEN endAppealOutcome = "Withdrawn"
-                WHEN CaseStatus_end in(51) AND Outcome_end in (0) THEN endAppealOutcome = "Struck out"
-                WHEN CaseStatus_end in(10) AND Outcome_end in (125) THEN endAppealOutcome = "Struck out"
+                WHEN CaseStatus_end in(52) AND Outcome_end in (91,95) THEN endAppealOutcome <=> "Struck out"
+                WHEN CaseStatus_end in(51) AND Outcome_end in (93,94) THEN endAppealOutcome <=> "Struck out"
+                WHEN CaseStatus_end in(10) AND Outcome_end in (2,120) THEN endAppealOutcome <=> "Struck out"
+                WHEN CaseStatus_end in(46) AND Outcome_end in (31) THEN endAppealOutcome <=> "Struck out"
+                WHEN CaseStatus_end in(10) AND Outcome_end in (105) THEN endAppealOutcome <=> "Struck out"
+                WHEN CaseStatus_end in(36) AND Outcome_end in (1,2) THEN endAppealOutcome <=> "Struck out"
+                WHEN CaseStatus_end in(36) AND Outcome_end in (25) THEN endAppealOutcome <=> "Withdrawn"
+                WHEN CaseStatus_end in(51) AND Outcome_end in (0) THEN endAppealOutcome <=> "Struck out"
+                WHEN CaseStatus_end in(10) AND Outcome_end in (125) THEN endAppealOutcome <=> "Struck out"
+                ELSE FALSE
             END
         )"""
 
         checks["valid_endAppealOutcomeReason"] = """(
             (
-                (CaseStatus_end = 10 AND Outcome_end IN (80,122,25,120,2,105,13))
+                (CaseStatus_end <=> 10 AND Outcome_end IS NOT NULL AND Outcome_end IN (80,122,25,120,2,105,13))
                 OR
-                (CaseStatus_end = 46 AND Outcome_end = 31)
+                (CaseStatus_end <=> 46 AND Outcome_end <=> 31)
                 OR
-                (CaseStatus_end = 26 AND Outcome_end IN (80,13,25))
+                (CaseStatus_end <=> 26 AND Outcome_end IS NOT NULL AND Outcome_end IN (80,13,25))
                 OR
-                (CaseStatus_end IN (37,38) AND Outcome_end IN (80,13,25,72,125))
+                (CaseStatus_end IS NOT NULL AND CaseStatus_end IN (37,38) AND Outcome_end IS NOT NULL AND Outcome_end IN (80,13,25,72,125))
                 OR
-                (CaseStatus_end = 39 AND Outcome_end = 25)
+                (CaseStatus_end <=> 39 AND Outcome_end <=> 25)
                 OR
-                (CaseStatus_end = 51 AND Outcome_end IN (0,94,93))
+                (CaseStatus_end <=> 51 AND Outcome_end IS NOT NULL AND Outcome_end IN (0,94,93))
                 OR
-                (CaseStatus_end = 52 AND Outcome_end IN (91,95))
+                (CaseStatus_end <=> 52 AND Outcome_end IS NOT NULL AND Outcome_end IN (91,95))
                 OR
-                (CaseStatus_end = 36 AND Outcome_end IN (1,2,25))
+                (CaseStatus_end <=> 36 AND Outcome_end IS NOT NULL AND Outcome_end IN (1,2,25))
             )
 
             AND
 
             (CASE
-                WHEN CaseStatus_end = 37 AND Outcome_end = 125 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier - Hearing | LA - Case Listed in CCD."
-                WHEN CaseStatus_end = 37 AND Outcome_end = 80 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier - Hearing | Abandoned."
-                WHEN CaseStatus_end = 38 AND Outcome_end = 80 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier - Paper | Abandoned."
-                WHEN CaseStatus_end = 38 AND Outcome_end = 125 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier - Paper | LA - Case Listed in CCD."
-                WHEN CaseStatus_end = 10 AND Outcome_end = 80 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Preliminary Issue | Abandoned."
-                WHEN CaseStatus_end = 10 AND Outcome_end = 122 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Preliminary Issue | Abandoned (non-CCD)."
-                WHEN CaseStatus_end = 10 AND Outcome_end = 13 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Preliminary Issue | No Valid Appeal."
-                WHEN CaseStatus_end = 26 AND Outcome_end = 80 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Case Management Review | Abandoned."
-                WHEN CaseStatus_end = 51 AND Outcome_end = 94 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Closed - Fee Not Paid | Struck Out."
-                WHEN CaseStatus_end = 37 AND Outcome_end = 13 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier - Hearing | No Valid Appeal."
-                WHEN CaseStatus_end = 38 AND Outcome_end = 13 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier - Paper | No Valid Appeal."
-                WHEN CaseStatus_end = 26 AND Outcome_end = 13 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Case Management Review | No Valid Appeal."
-                WHEN CaseStatus_end = 37 AND Outcome_end = 25 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier - Hearing | Withdrawn."
-                WHEN CaseStatus_end = 38 AND Outcome_end = 25 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier - Paper | Withdrawn."
-                WHEN CaseStatus_end = 39 AND Outcome_end = 25 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier Permission Application | Withdrawn."
-                WHEN CaseStatus_end = 10 AND Outcome_end = 25 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Preliminary Issue | Withdrawn."
-                WHEN CaseStatus_end = 26 AND Outcome_end = 25 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Case Management Review | Withdrawn."
-                WHEN CaseStatus_end = 52 AND Outcome_end = 91 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Case closed fee outstanding | Fee Paid/Exempt."
-                WHEN CaseStatus_end = 52 AND Outcome_end = 95 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Case closed fee outstanding | Write Off."
-                WHEN CaseStatus_end = 51 AND Outcome_end = 93 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Closed - Fee Not Paid | Admin Closure."
-                WHEN CaseStatus_end = 38 AND Outcome_end = 72 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was First Tier - Paper | Certified under Rule 16."
-                WHEN CaseStatus_end = 10 AND Outcome_end = 120 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Preliminary Issue | Admin Rejected (Non-CCD)."
-                WHEN CaseStatus_end = 10 AND Outcome_end = 2 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Preliminary Issue | Dismissed."
-                WHEN CaseStatus_end = 46 AND Outcome_end = 31 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Set Aside Application | Refused."
-                WHEN CaseStatus_end = 36 AND Outcome_end = 1 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Review of Cost Order | Allowed."
-                WHEN CaseStatus_end = 36 AND Outcome_end = 2 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Review of Cost Order | Dismissed."
-                WHEN CaseStatus_end = 36 AND Outcome_end = 25 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Review of Cost Order | Withdrawn."
-                WHEN CaseStatus_end = 51 AND Outcome_end = 0 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Closed - Fee Not Paid | Struck out."
-                WHEN CaseStatus_end = 10 AND Outcome_end = 105 THEN endAppealOutcomeReason = "This is a migrated case. The final outcome was Preliminary Issue | Reinstatement Out of Time."
+                WHEN CaseStatus_end = 37 AND Outcome_end = 125 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier - Hearing | LA - Case Listed in CCD."
+                WHEN CaseStatus_end = 37 AND Outcome_end = 80 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier - Hearing | Abandoned."
+                WHEN CaseStatus_end = 38 AND Outcome_end = 80 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier - Paper | Abandoned."
+                WHEN CaseStatus_end = 38 AND Outcome_end = 125 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier - Paper | LA - Case Listed in CCD."
+                WHEN CaseStatus_end = 10 AND Outcome_end = 80 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Preliminary Issue | Abandoned."
+                WHEN CaseStatus_end = 10 AND Outcome_end = 122 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Preliminary Issue | Abandoned (non-CCD)."
+                WHEN CaseStatus_end = 10 AND Outcome_end = 13 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Preliminary Issue | No Valid Appeal."
+                WHEN CaseStatus_end = 26 AND Outcome_end = 80 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Case Management Review | Abandoned."
+                WHEN CaseStatus_end = 51 AND Outcome_end = 94 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Closed - Fee Not Paid | Struck Out."
+                WHEN CaseStatus_end = 37 AND Outcome_end = 13 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier - Hearing | No Valid Appeal."
+                WHEN CaseStatus_end = 38 AND Outcome_end = 13 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier - Paper | No Valid Appeal."
+                WHEN CaseStatus_end = 26 AND Outcome_end = 13 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Case Management Review | No Valid Appeal."
+                WHEN CaseStatus_end = 37 AND Outcome_end = 25 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier - Hearing | Withdrawn."
+                WHEN CaseStatus_end = 38 AND Outcome_end = 25 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier - Paper | Withdrawn."
+                WHEN CaseStatus_end = 39 AND Outcome_end = 25 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier Permission Application | Withdrawn."
+                WHEN CaseStatus_end = 10 AND Outcome_end = 25 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Preliminary Issue | Withdrawn."
+                WHEN CaseStatus_end = 26 AND Outcome_end = 25 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Case Management Review | Withdrawn."
+                WHEN CaseStatus_end = 52 AND Outcome_end = 91 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Case closed fee outstanding | Fee Paid/Exempt."
+                WHEN CaseStatus_end = 52 AND Outcome_end = 95 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Case closed fee outstanding | Write Off."
+                WHEN CaseStatus_end = 51 AND Outcome_end = 93 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Closed - Fee Not Paid | Admin Closure."
+                WHEN CaseStatus_end = 38 AND Outcome_end = 72 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was First Tier - Paper | Certified under Rule 16."
+                WHEN CaseStatus_end = 10 AND Outcome_end = 120 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Preliminary Issue | Admin Rejected (Non-CCD)."
+                WHEN CaseStatus_end = 10 AND Outcome_end = 2 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Preliminary Issue | Dismissed."
+                WHEN CaseStatus_end <=> 46 AND Outcome_end <=> 31 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Set Aside Application | Refused."
+                WHEN CaseStatus_end = 36 AND Outcome_end = 1 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Review of Cost Order | Allowed."
+                WHEN CaseStatus_end = 36 AND Outcome_end = 2 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Review of Cost Order | Dismissed."
+                WHEN CaseStatus_end = 36 AND Outcome_end = 25 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Review of Cost Order | Withdrawn."
+                WHEN CaseStatus_end = 51 AND Outcome_end = 0 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Closed - Fee Not Paid | Struck out."
+                WHEN CaseStatus_end = 10 AND Outcome_end = 105 THEN endAppealOutcomeReason <=> "This is a migrated case. The final outcome was Preliminary Issue | Reinstatement Out of Time."
+                ELSE FALSE
             END
             )
         )"""
 
         checks["valid_endAppealApproverType"] = """(
             CASE
-                WHEN CaseStatus_end = 46 THEN endAppealApproverType = 'Judge'
-                ELSE endAppealApproverType = 'Case Worker'
+                WHEN CaseStatus_end = 46 THEN endAppealApproverType <=> 'Judge'
+                ELSE endAppealApproverType <=> 'Case Worker'
             END
         )"""
 
         checks["valid_endAppealApproverName"] = """(
             CASE
-                WHEN CaseStatus_end = 46 THEN endAppealApproverName = concat(Adj_Determination_Surname_end, ', ', Adj_Determination_Forenames_end, ' (', Adj_Determination_Title_end, ')')
-                ELSE endAppealApproverName = 'This is a migrated ARIA case'
+                WHEN CaseStatus_end = 46 THEN concat(Adj_Determination_Surname_end, ', ', Adj_Determination_Forenames_end, ' (', Adj_Determination_Title_end, ')') IS NOT NULL AND endAppealApproverName <=> concat(Adj_Determination_Surname_end, ', ', Adj_Determination_Forenames_end, ' (', Adj_Determination_Title_end, ')')
+                ELSE endAppealApproverName <=> 'This is a migrated ARIA case'
             END
         )"""
 
         checks["valid_endAppealDate"] = """(
             (
-                (CaseStatus_end = 10 AND Outcome_end IN (80,122,25,120,2,105,13))
+                (CaseStatus_end <=> 10 AND Outcome_end IS NOT NULL AND Outcome_end IN (80,122,25,120,2,105,13))
                 OR
-                (CaseStatus_end = 46 AND Outcome_end = 31)
+                (CaseStatus_end <=> 46 AND Outcome_end <=> 31)
                 OR
-                (CaseStatus_end = 26 AND Outcome_end IN (80,13,25))
+                (CaseStatus_end <=> 26 AND Outcome_end IS NOT NULL AND Outcome_end IN (80,13,25))
                 OR
-                (CaseStatus_end IN (37,38) AND Outcome_end IN (80,13,25,72,125))
+                (CaseStatus_end IS NOT NULL AND CaseStatus_end IN (37,38) AND Outcome_end IS NOT NULL AND Outcome_end IN (80,13,25,72,125))
                 OR
-                (CaseStatus_end = 39 AND Outcome_end = 25)
+                (CaseStatus_end <=> 39 AND Outcome_end <=> 25)
                 OR
-                (CaseStatus_end = 51 AND Outcome_end IN (0,94,93))
+                (CaseStatus_end <=> 51 AND Outcome_end IS NOT NULL AND Outcome_end IN (0,94,93))
                 OR
-                (CaseStatus_end = 52 AND Outcome_end IN (91,95))
+                (CaseStatus_end <=> 52 AND Outcome_end IS NOT NULL AND Outcome_end IN (91,95))
                 OR
-                (CaseStatus_end = 36 AND Outcome_end IN (1,2,25))
+                (CaseStatus_end <=> 36 AND Outcome_end IS NOT NULL AND Outcome_end IN (1,2,25))
             )
 
             AND
 
-            (endAppealDate = date_format(to_date(DecisionDate_end), 'yyyy-MM-dd'))
+            (
+                date_format(to_date(DecisionDate_end), 'yyyy-MM-dd') IS NOT NULL
+                AND endAppealDate <=> date_format(to_date(DecisionDate_end), 'yyyy-MM-dd')
+            )
         )"""
 
         checks["valid_stateBeforeEndAppeal"] = """(
             (
-                (CaseStatus_end = 10 AND Outcome_end IN (80,122,25,120,2,105,13))
+                (CaseStatus_end <=> 10 AND Outcome_end IS NOT NULL AND Outcome_end IN (80,122,25,120,2,105,13))
                 OR
-                (CaseStatus_end = 46 AND Outcome_end = 31)
+                (CaseStatus_end <=> 46 AND Outcome_end <=> 31)
                 OR
-                (CaseStatus_end = 26 AND Outcome_end IN (80,13,25))
+                (CaseStatus_end <=> 26 AND Outcome_end IS NOT NULL AND Outcome_end IN (80,13,25))
                 OR
-                (CaseStatus_end IN (37,38) AND Outcome_end IN (80,13,25,72,125))
+                (CaseStatus_end IS NOT NULL AND CaseStatus_end IN (37,38) AND Outcome_end IS NOT NULL AND Outcome_end IN (80,13,25,72,125))
                 OR
-                (CaseStatus_end = 39 AND Outcome_end = 25)
+                (CaseStatus_end <=> 39 AND Outcome_end <=> 25)
                 OR
-                (CaseStatus_end = 51 AND Outcome_end IN (0,94,93))
+                (CaseStatus_end <=> 51 AND Outcome_end IS NOT NULL AND Outcome_end IN (0,94,93))
                 OR
-                (CaseStatus_end = 52 AND Outcome_end IN (91,95))
+                (CaseStatus_end <=> 52 AND Outcome_end IS NOT NULL AND Outcome_end IN (91,95))
                 OR
-                (CaseStatus_end = 36 AND Outcome_end IN (1,2,25))
+                (CaseStatus_end <=> 36 AND Outcome_end IS NOT NULL AND Outcome_end IN (1,2,25))
             )
 
             AND
 
             (CASE
-                WHEN CaseStatus_end in(37,38) AND Outcome_end in (80,13,25,125) THEN stateBeforeEndAppeal = "listing"
-                WHEN CaseStatus_end = 38 AND Outcome_end = 72 THEN stateBeforeEndAppeal = "listing"
-                WHEN CaseStatus_end = 10 AND Outcome_end in (80,122,25,2,120) THEN stateBeforeEndAppeal = "appealSubmitted"
-                WHEN CaseStatus_end = 46 AND Outcome_end = 31 THEN stateBeforeEndAppeal = "appealSubmitted"
-                WHEN CaseStatus_end = 51 AND Outcome_end in (0,94,93) THEN stateBeforeEndAppeal = "pendingPayment"
-                WHEN CaseStatus_end = 52 AND Outcome_end in (95,91) THEN stateBeforeEndAppeal = "pendingPayment"
-                WHEN CaseStatus_end = 39 AND Outcome_end = 25 THEN stateBeforeEndAppeal = "ftpaSubmitted"
-                WHEN CaseStatus_end = 26 AND Outcome_end in (13,25,80) AND dv_representation = "LR" THEN stateBeforeEndAppeal = "caseUnderReview"
-                WHEN CaseStatus_end = 26 AND Outcome_end in (13,25,80) AND dv_representation = "AIP" THEN stateBeforeEndAppeal = "reasonsForAppealSubmitted"
-                WHEN CaseStatus_end = 36 AND Outcome_end in (1,2,25) THEN stateBeforeEndAppeal = "appealSubmitted"
-                WHEN CaseStatus_end = 10 AND Outcome_end in (13,105) THEN stateBeforeEndAppeal = "appealSubmitted"
+                WHEN CaseStatus_end in(37,38) AND Outcome_end in (80,13,25,125) THEN stateBeforeEndAppeal <=> "listing"
+                WHEN CaseStatus_end = 38 AND Outcome_end = 72 THEN stateBeforeEndAppeal <=> "listing"
+                WHEN CaseStatus_end = 10 AND Outcome_end in (80,122,25,2,120) THEN stateBeforeEndAppeal <=> "appealSubmitted"
+                WHEN CaseStatus_end <=> 46 AND Outcome_end <=> 31 THEN stateBeforeEndAppeal <=> "appealSubmitted"
+                WHEN CaseStatus_end = 51 AND Outcome_end in (0,94,93) THEN stateBeforeEndAppeal <=> "pendingPayment"
+                WHEN CaseStatus_end = 52 AND Outcome_end in (95,91) THEN stateBeforeEndAppeal <=> "pendingPayment"
+                WHEN CaseStatus_end = 39 AND Outcome_end = 25 THEN stateBeforeEndAppeal <=> "ftpaSubmitted"
+                WHEN CaseStatus_end = 26 AND Outcome_end in (13,25,80) AND dv_representation = "LR" THEN stateBeforeEndAppeal <=> "caseUnderReview"
+                WHEN CaseStatus_end = 26 AND Outcome_end in (13,25,80) AND dv_representation = "AIP" THEN stateBeforeEndAppeal <=> "reasonsForAppealSubmitted"
+                WHEN CaseStatus_end = 36 AND Outcome_end in (1,2,25) THEN stateBeforeEndAppeal <=> "appealSubmitted"
+                WHEN CaseStatus_end = 10 AND Outcome_end in (13,105) THEN stateBeforeEndAppeal <=> "appealSubmitted"
+                ELSE FALSE
             END)
         )"""
 
@@ -208,7 +214,7 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 38 AND Outcome_ended = 72) OR
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
-                    COALESCE(respondentDocuments, ARRAY()) = COALESCE(respondentDocuments_ended, ARRAY())
+                    to_json(COALESCE(respondentDocuments, ARRAY())) <=> to_json(COALESCE(respondentDocuments_ended, ARRAY()))
                 ELSE
                     respondentDocuments IS NULL
             END
@@ -223,7 +229,7 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 38 AND Outcome_ended = 72) OR
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
-                    COALESCE(hearingRequirements, ARRAY()) = COALESCE(hearingRequirements_ended, ARRAY())
+                    to_json(COALESCE(hearingRequirements, ARRAY())) <=> to_json(COALESCE(hearingRequirements_ended, ARRAY()))
                 ELSE
                     hearingRequirements IS NULL
             END
@@ -236,7 +242,7 @@ class endedDQRules(DQRulesBase):
                 WHEN (
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
-                    COALESCE(hearingDocuments, ARRAY()) = COALESCE(hearingDocuments_ended, ARRAY())
+                    to_json(COALESCE(hearingDocuments, ARRAY())) <=> to_json(COALESCE(hearingDocuments_ended, ARRAY()))
                 ELSE
                     hearingDocuments IS NULL
             END
@@ -249,7 +255,7 @@ class endedDQRules(DQRulesBase):
                 WHEN (
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
-                    COALESCE(letterBundleDocuments, ARRAY()) = COALESCE(letterBundleDocuments_ended, ARRAY())
+                    to_json(COALESCE(letterBundleDocuments, ARRAY())) <=> to_json(COALESCE(letterBundleDocuments_ended, ARRAY()))
                 ELSE
                     letterBundleDocuments IS NULL
             END
@@ -262,7 +268,7 @@ class endedDQRules(DQRulesBase):
                 WHEN (
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
-                    COALESCE(caseBundles, ARRAY()) = COALESCE(caseBundles_ended, ARRAY())
+                    to_json(COALESCE(caseBundles, ARRAY())) <=> to_json(COALESCE(caseBundles_ended, ARRAY()))
                 ELSE
                     caseBundles IS NULL
             END
@@ -275,7 +281,7 @@ class endedDQRules(DQRulesBase):
                 WHEN (
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
-                    COALESCE(finalDecisionAndReasonsDocuments, ARRAY()) = COALESCE(finalDecisionAndReasonsDocuments_ended, ARRAY())
+                    to_json(COALESCE(finalDecisionAndReasonsDocuments, ARRAY())) <=> to_json(COALESCE(finalDecisionAndReasonsDocuments_ended, ARRAY()))
                 ELSE
                     finalDecisionAndReasonsDocuments IS NULL
             END
@@ -290,7 +296,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN size(ftpaAppellantDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN COALESCE(size(ftpaAppellantDocuments), 0) = 0
                 ELSE ftpaAppellantDocuments IS NULL
             END
         )
@@ -308,7 +314,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN size(ftpaRespondentDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN COALESCE(size(ftpaRespondentDocuments), 0) = 0
                 ELSE ftpaRespondentDocuments IS NULL
             END
         )
@@ -326,7 +332,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN size(ftpaAppellantGroundsDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN COALESCE(size(ftpaAppellantGroundsDocuments), 0) = 0
                 ELSE ftpaAppellantGroundsDocuments IS NULL
             END
         )
@@ -344,7 +350,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN size(ftpaRespondentGroundsDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN COALESCE(size(ftpaRespondentGroundsDocuments), 0) = 0
                 ELSE ftpaRespondentGroundsDocuments IS NULL
             END
         )
@@ -362,7 +368,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN size(ftpaAppellantEvidenceDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN COALESCE(size(ftpaAppellantEvidenceDocuments), 0) = 0
                 ELSE ftpaAppellantEvidenceDocuments IS NULL
             END
         )
@@ -380,7 +386,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN size(ftpaRespondentEvidenceDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN COALESCE(size(ftpaRespondentEvidenceDocuments), 0) = 0
                 ELSE ftpaRespondentEvidenceDocuments IS NULL
             END
         )
@@ -398,7 +404,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN size(ftpaAppellantOutOfTimeDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN COALESCE(size(ftpaAppellantOutOfTimeDocuments), 0) = 0
                 ELSE ftpaAppellantOutOfTimeDocuments IS NULL
             END
         )
@@ -416,7 +422,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN size(ftpaRespondentOutOfTimeDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN COALESCE(size(ftpaRespondentOutOfTimeDocuments), 0) = 0
                 ELSE ftpaRespondentOutOfTimeDocuments IS NULL
             END
         )
@@ -452,18 +458,18 @@ class endedDQRules(DQRulesBase):
                     (
         -- Case: VisitVisaType = 1
         (
-            VisitVisaType = 1 AND
-            hearingChannel.value.code = 'ONPPRS' AND
-            hearingChannel.value.label = 'On The Papers'
+            VisitVisaType <=> 1 AND
+            hearingChannel.value.code <=> 'ONPPRS' AND
+            hearingChannel.value.label <=> 'On The Papers'
         )
         )
         OR
         (
         -- Case: VisitVisaType = 2
         (
-            VisitVisaType = 2 AND
-            hearingChannel.value.code = 'INTER' AND
-            hearingChannel.value.label = 'In Person'
+            VisitVisaType <=> 2 AND
+            hearingChannel.value.code <=> 'INTER' AND
+            hearingChannel.value.label <=> 'In Person'
         )
         )
         OR
@@ -486,7 +492,7 @@ class endedDQRules(DQRulesBase):
                 WHEN (
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
-                    COALESCE(witnessDetails, ARRAY()) = COALESCE(witnessDetails_ended, ARRAY())
+                    to_json(COALESCE(witnessDetails, ARRAY())) <=> to_json(COALESCE(witnessDetails_ended, ARRAY()))
                 ELSE
                     witnessDetails IS NULL
             END
@@ -860,7 +866,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN ftpaAppellantApplicationDate = date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd') IS NOT NULL AND ftpaAppellantApplicationDate <=> date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
                 ELSE ftpaAppellantApplicationDate IS NULL
             END
         )
@@ -878,8 +884,8 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN ftpaAppellantSubmissionOutOfTime = 'Yes'
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime != 1 THEN ftpaAppellantSubmissionOutOfTime = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN ftpaAppellantSubmissionOutOfTime <=> 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime != 1 THEN ftpaAppellantSubmissionOutOfTime <=> 'No'
                 ELSE ftpaAppellantSubmissionOutOfTime IS NULL
             END
         )
@@ -897,7 +903,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN ftpaAppellantOutOfTimeExplanation = 'This is a migrated ARIA case. Please check the Documents, FTPA tab or Case Notes tab for reasons for lateness.'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN ftpaAppellantOutOfTimeExplanation <=> 'This is a migrated ARIA case. Please check the Documents, FTPA tab or Case Notes tab for reasons for lateness.'
                 ELSE ftpaAppellantOutOfTimeExplanation IS NULL
             END
         )
@@ -915,7 +921,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN ftpaRespondentApplicationDate = date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd') IS NOT NULL AND ftpaRespondentApplicationDate <=> date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
                 ELSE ftpaRespondentApplicationDate IS NULL
             END
         )
@@ -933,8 +939,8 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN ftpaRespondentSubmissionOutOfTime = 'Yes'
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime != 1 THEN ftpaRespondentSubmissionOutOfTime = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN ftpaRespondentSubmissionOutOfTime <=> 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime != 1 THEN ftpaRespondentSubmissionOutOfTime <=> 'No'
                 ELSE ftpaRespondentSubmissionOutOfTime IS NULL
             END
         )
@@ -952,7 +958,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN ftpaRespondentOutOfTimeExplanation = 'This is a migrated ARIA case. Please check the Documents, FTPA tab or Case Notes tab for reasons for lateness.'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN ftpaRespondentOutOfTimeExplanation <=> 'This is a migrated ARIA case. Please check the Documents, FTPA tab or Case Notes tab for reasons for lateness.'
                 ELSE ftpaRespondentOutOfTimeExplanation IS NULL
             END
         )
@@ -1081,11 +1087,11 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-            CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-            AND 
+            CaseStatus_SD IS NOT NULL AND CaseStatus_SD IN (37,38,26) AND Outcome_SD IS NOT NULL AND Outcome_SD IN (1,2)
+            AND
             CASE
-                WHEN Outcome_SD = 1 THEN (appealDecision = 'Allowed')
-                WHEN Outcome_SD = 2 THEN (appealDecision = 'Dismissed')
+                WHEN Outcome_SD = 1 THEN (appealDecision <=> 'Allowed')
+                WHEN Outcome_SD = 2 THEN (appealDecision <=> 'Dismissed')
             END
         )
                 ELSE
@@ -1101,11 +1107,11 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-            CaseStatus_SD IN (37,38,26) AND Outcome_SD IN (1,2)
-            AND 
+            CaseStatus_SD IS NOT NULL AND CaseStatus_SD IN (37,38,26) AND Outcome_SD IS NOT NULL AND Outcome_SD IN (1,2)
+            AND
             CASE
-                WHEN Outcome_SD = 1 THEN (isDecisionAllowed = 'allowed')
-                WHEN Outcome_SD = 2 THEN (isDecisionAllowed = 'dismissed')
+                WHEN Outcome_SD = 1 THEN (isDecisionAllowed <=> 'allowed')
+                WHEN Outcome_SD = 2 THEN (isDecisionAllowed <=> 'dismissed')
                 ELSE (isDecisionAllowed IS NULL)
             END
         )
@@ -1154,9 +1160,9 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-                (listTypeId = 5 AND isAppealSuitableToFloat = 'Yes')
+                (listTypeId <=> 5 AND isAppealSuitableToFloat <=> 'Yes')
                 OR
-                ((listTypeId != 5 OR listTypeId IS NULL) AND isAppealSuitableToFloat = 'No')
+                ((listTypeId != 5 OR listTypeId IS NULL) AND isAppealSuitableToFloat <=> 'No')
             )
                 ELSE
                     isAppealSuitableToFloat IS NULL
@@ -1210,9 +1216,9 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-                (InCamera = 1 AND isInCameraCourtAllowed = 'Granted')
+                (InCamera <=> 1 AND isInCameraCourtAllowed <=> 'Granted')
                 OR
-                (InCamera != 1 AND isInCameraCourtAllowed IS NULL)
+                (NOT(InCamera <=> 1) AND isInCameraCourtAllowed IS NULL)
             )
                 ELSE
                     isInCameraCourtAllowed IS NULL
@@ -1227,9 +1233,9 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-                (InCamera = 1 AND inCameraCourtTribunalResponse = 'This is a migrated ARIA case. Please refer to the documents.')
+                (InCamera <=> 1 AND inCameraCourtTribunalResponse <=> 'This is a migrated ARIA case. Please refer to the documents.')
                 OR
-                (InCamera != 1 AND inCameraCourtTribunalResponse IS NULL)
+                (NOT(InCamera <=> 1) AND inCameraCourtTribunalResponse IS NULL)
             )
                 ELSE
                     inCameraCourtTribunalResponse IS NULL
@@ -1244,9 +1250,9 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-                (InCamera = 1 AND inCameraCourtDecisionForDisplay = 'Granted - This is a migrated ARIA case. Please refer to the documents.')
+                (InCamera <=> 1 AND inCameraCourtDecisionForDisplay <=> 'Granted - This is a migrated ARIA case. Please refer to the documents.')
                 OR
-                (InCamera != 1 AND inCameraCourtDecisionForDisplay IS NULL)
+                (NOT(InCamera <=> 1) AND inCameraCourtDecisionForDisplay IS NULL)
             )
                 ELSE
                     inCameraCourtDecisionForDisplay IS NULL
@@ -1261,9 +1267,9 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-                (CourtPreference IN (1, 2) AND isSingleSexCourtAllowed = 'Granted')
+                (CourtPreference IS NOT NULL AND CourtPreference IN (1, 2) AND isSingleSexCourtAllowed <=> 'Granted')
                 OR
-                (CourtPreference NOT IN (1, 2) AND isSingleSexCourtAllowed IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND isSingleSexCourtAllowed IS NULL)
             )
                 ELSE
                     isSingleSexCourtAllowed IS NULL
@@ -1278,9 +1284,9 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-                (CourtPreference IN (1, 2) AND singleSexCourtTribunalResponse = 'This is a migrated ARIA case. Please refer to the documents.')
+                (CourtPreference IS NOT NULL AND CourtPreference IN (1, 2) AND singleSexCourtTribunalResponse <=> 'This is a migrated ARIA case. Please refer to the documents.')
                 OR
-                (CourtPreference NOT IN (1, 2)  AND singleSexCourtTribunalResponse IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND singleSexCourtTribunalResponse IS NULL)
             )
                 ELSE
                     singleSexCourtTribunalResponse IS NULL
@@ -1295,9 +1301,9 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-                (CourtPreference IN (1, 2)  AND singleSexCourtDecisionForDisplay = 'Granted - This is a migrated ARIA case. Please refer to the documents.')
+                (CourtPreference IS NOT NULL AND CourtPreference IN (1, 2) AND singleSexCourtDecisionForDisplay <=> 'Granted - This is a migrated ARIA case. Please refer to the documents.')
                 OR
-                (CourtPreference NOT IN (1, 2)  AND singleSexCourtDecisionForDisplay IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND singleSexCourtDecisionForDisplay IS NULL)
             )
                 ELSE
                     singleSexCourtDecisionForDisplay IS NULL
@@ -1563,7 +1569,7 @@ class endedDQRules(DQRulesBase):
                 OR
                 (Interpreter <=> 2 AND isInterpreterServicesNeeded <=> 'No')
                 OR
-                (Interpreter NOT IN (1, 2) AND isInterpreterServicesNeeded <=> 'No')
+                ((Interpreter IS NULL OR Interpreter NOT IN (1, 2)) AND isInterpreterServicesNeeded <=> 'No')
             )
                 ELSE
                     isInterpreterServicesNeeded IS NULL
@@ -1579,7 +1585,7 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 38 AND Outcome_ended = 72) OR
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
-                    COALESCE(appellantInterpreterLanguageCategory, ARRAY()) = COALESCE(appellantInterpreterLanguageCategory_ended, ARRAY())
+                    to_json(COALESCE(appellantInterpreterLanguageCategory, ARRAY())) <=> to_json(COALESCE(appellantInterpreterLanguageCategory_ended, ARRAY()))
                 ELSE
                     appellantInterpreterLanguageCategory IS NULL
             END
@@ -1779,7 +1785,7 @@ class endedDQRules(DQRulesBase):
                 OR
                 ((CourtPreference <=> 1 OR CourtPreference <=> 2) AND singleSexCourt <=> 'Yes')
                 OR
-                (CourtPreference NOT IN (0, 1, 2) AND singleSexCourt <=> 'No')
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (0, 1, 2)) AND singleSexCourt <=> 'No')
             )
                 ELSE
                     singleSexCourt IS NULL
@@ -1800,7 +1806,7 @@ class endedDQRules(DQRulesBase):
                 OR
                 (CourtPreference <=> 2 AND singleSexCourtType <=> 'All female')
                 OR
-                (CourtPreference NOT IN (1, 2) AND singleSexCourtType IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND singleSexCourtType IS NULL)
             )
                 ELSE
                     singleSexCourtType IS NULL
@@ -1819,7 +1825,7 @@ class endedDQRules(DQRulesBase):
                     (
                 ((CourtPreference <=> 1 OR CourtPreference <=> 2) AND singleSexCourtTypeDescription <=> 'This is an ARIA migrated case. Please refer to the hearing requirements in the appeal form for further details on the single sex court.')
                 OR
-                (CourtPreference NOT IN (1, 2) AND singleSexCourtTypeDescription IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND singleSexCourtTypeDescription IS NULL)
             )
                 ELSE
                     singleSexCourtTypeDescription IS NULL
@@ -1925,7 +1931,7 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
                     (
-                        (appellantLevelFlags IS NOT NULL)
+                        (appellantLevelFlags IS NOT NULL AND appellantLevelFlags.details IS NOT NULL)
                         AND
                         (ARRAY_SIZE(appellantLevelFlags.details) >= 3)
                         AND
@@ -1949,7 +1955,7 @@ class endedDQRules(DQRulesBase):
                     )
                 ELSE
                     (
-                        (appellantLevelFlags IS NOT NULL)
+                        (appellantLevelFlags IS NOT NULL AND appellantLevelFlags.details IS NOT NULL)
                         AND
                         (ARRAY_SIZE(appellantLevelFlags.details) >= 3)
                         AND
@@ -1979,7 +1985,7 @@ class endedDQRules(DQRulesBase):
                     (CaseStatus_ended = 38 AND Outcome_ended = 72) OR
                     (CaseStatus_ended = 39 AND Outcome_ended = 25)
                 ) THEN
-                    COALESCE(directions, ARRAY()) = COALESCE(directions_ended, ARRAY())
+                    to_json(COALESCE(directions, ARRAY())) <=> to_json(COALESCE(directions_ended, ARRAY()))
                 ELSE
                     directions IS NULL
             END
@@ -2271,7 +2277,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                    (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN ftpaAppellantSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN ftpaAppellantSubmitted <=> 'Yes'
                 ELSE ftpaAppellantSubmitted IS NULL
             END
         )
@@ -2289,7 +2295,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantDocsVisibleInDecided IS NULL
             END
         )
@@ -2307,7 +2313,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantDocsVisibleInSubmitted IS NULL
             END
         )
@@ -2325,7 +2331,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantOotDocsVisibleInDecided IS NULL
             END
         )
@@ -2343,7 +2349,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantOotDocsVisibleInSubmitted IS NULL
             END
         )
@@ -2361,7 +2367,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantGroundsDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantGroundsDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantGroundsDocsVisibleInDecided IS NULL
             END
         )
@@ -2379,7 +2385,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantEvidenceDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantEvidenceDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantEvidenceDocsVisibleInDecided IS NULL
             END
         )
@@ -2397,7 +2403,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantGroundsDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantGroundsDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantGroundsDocsVisibleInSubmitted IS NULL
             END
         )
@@ -2415,7 +2421,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantEvidenceDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantEvidenceDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantEvidenceDocsVisibleInSubmitted IS NULL
             END
         )
@@ -2433,7 +2439,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotExplanationVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotExplanationVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantOotExplanationVisibleInDecided IS NULL
             END
         )
@@ -2451,7 +2457,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotExplanationVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotExplanationVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantOotExplanationVisibleInSubmitted IS NULL
             END
         )
@@ -2469,7 +2475,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN ftpaRespondentSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN ftpaRespondentSubmitted <=> 'Yes'
                 ELSE ftpaRespondentSubmitted IS NULL
             END
         )
@@ -2487,7 +2493,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentDocsVisibleInDecided IS NULL
             END
         )
@@ -2505,7 +2511,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentDocsVisibleInSubmitted IS NULL
             END
         )
@@ -2523,7 +2529,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentOotDocsVisibleInDecided IS NULL
             END
         )
@@ -2541,7 +2547,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentOotDocsVisibleInSubmitted IS NULL
             END
         )
@@ -2559,7 +2565,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentGroundsDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentGroundsDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentGroundsDocsVisibleInDecided IS NULL
             END
         )
@@ -2577,7 +2583,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentEvidenceDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentEvidenceDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentEvidenceDocsVisibleInDecided IS NULL
             END
         )
@@ -2595,7 +2601,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentGroundsDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentGroundsDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentGroundsDocsVisibleInSubmitted IS NULL
             END
         )
@@ -2613,7 +2619,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentEvidenceDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentEvidenceDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentEvidenceDocsVisibleInSubmitted IS NULL
             END
         )
@@ -2631,7 +2637,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotExplanationVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotExplanationVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentOotExplanationVisibleInDecided IS NULL
             END
         )
@@ -2649,7 +2655,7 @@ class endedDQRules(DQRulesBase):
                 ) THEN
                     (
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotExplanationVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotExplanationVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentOotExplanationVisibleInSubmitted IS NULL
             END
         )
@@ -2665,9 +2671,10 @@ class endedDQRules(DQRulesBase):
     def get_checks_TTL(self, checks={}):
 
         checks["valid_TTL"] = """(
-            TTL.Suspended = 'No'
+            TTL.Suspended <=> 'No'
             AND
-            TTL.SystemTTL = date_format(date_add(to_date(DecisionDate_no_filter), 730), 'yyyy-MM-dd')
+            date_format(date_add(to_date(DecisionDate_no_filter), 730), 'yyyy-MM-dd') IS NOT NULL
+            AND TTL.SystemTTL <=> date_format(date_add(to_date(DecisionDate_no_filter), 730), 'yyyy-MM-dd')
         )"""
 
         return checks
@@ -2677,13 +2684,13 @@ class endedDQRules(DQRulesBase):
 
         checks["valid_outOfTimeDecisionType"] = """
         (
-            CASE 
+            CASE
                 WHEN (
-                    (CaseStatus_max_no_filter = 10 AND Outcome_no_filter IN (120, 2, 105)) 
+                    (CaseStatus_max_no_filter IS NOT NULL AND CaseStatus_max_no_filter = 10 AND Outcome_no_filter IS NOT NULL AND Outcome_no_filter IN (120, 2, 105))
                 ) THEN
-                    outOfTimeDecisionType = 'rejected'
+                    outOfTimeDecisionType <=> 'rejected'
                 ELSE
-                    outOfTimeDecisionType = 'approved'
+                    outOfTimeDecisionType <=> 'approved'
             END
         )
         """

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ftpaDecided_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ftpaDecided_dq_rules.py
@@ -15,21 +15,21 @@ class ftpaDecidedDQRules(DQRulesBase):
         """
         (
             (
-                (cs_39_outcome_14_30_31 = 39 AND outcome_14_30_31_cs_39 IN (30,31,14))
+                (cs_39_outcome_14_30_31 <=> 39 AND outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14))
                 AND
                 (
-                    (cs39_party_14_30_31 = 1 AND ftpaApplicantType = 'appellant')
+                    (cs39_party_14_30_31 <=> 1 AND ftpaApplicantType <=> 'appellant')
                     OR
-                    (cs39_party_14_30_31 = 2 AND ftpaApplicantType = 'respondent')
+                    (cs39_party_14_30_31 <=> 2 AND ftpaApplicantType <=> 'respondent')
                     OR
-                    (cs39_party_14_30_31 NOT IN (1,2) AND ftpaApplicantType IS NULL)
+                    (cs39_party_14_30_31 IS NOT NULL AND cs39_party_14_30_31 NOT IN (1,2) AND ftpaApplicantType IS NULL)
                     OR
                     (cs39_party_14_30_31 IS NULL AND ftpaApplicantType IS NULL)
                 )
             )
             OR
             (
-                NOT (cs_39_outcome_14_30_31 = 39 OR outcome_14_30_31_cs_39 IN (30,31,14))
+                NOT (cs_39_outcome_14_30_31 <=> 39 OR (outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14)))
                 AND ftpaApplicantType IS NULL
             )
             OR
@@ -44,23 +44,23 @@ class ftpaDecidedDQRules(DQRulesBase):
         """
         (
             (
-                (cs_39_outcome_14_30_31 = 39 AND outcome_14_30_31_cs_39 IN (30,31,14))
+                (cs_39_outcome_14_30_31 <=> 39 AND outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14))
                 AND
                 (
-                    (outcome_14_30_31_cs_39 = 30 AND ftpaFirstDecision = 'granted')
+                    (outcome_14_30_31_cs_39 <=> 30 AND ftpaFirstDecision <=> 'granted')
                     OR
-                    (outcome_14_30_31_cs_39 = 31 AND ftpaFirstDecision = 'refused')
+                    (outcome_14_30_31_cs_39 <=> 31 AND ftpaFirstDecision <=> 'refused')
                     OR
-                    (outcome_14_30_31_cs_39 = 14 AND ftpaFirstDecision = 'notAdmitted')
+                    (outcome_14_30_31_cs_39 <=> 14 AND ftpaFirstDecision <=> 'notAdmitted')
                     OR
                     (outcome_14_30_31_cs_39 IS NULL AND ftpaFirstDecision IS NULL)
                     OR
-                    (outcome_14_30_31_cs_39 NOT IN (30,31,14) AND ftpaFirstDecision IS NULL)
+                    (outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 NOT IN (30,31,14) AND ftpaFirstDecision IS NULL)
                 )
             )
             OR
             (
-                NOT (cs_39_outcome_14_30_31 = 39 OR outcome_14_30_31_cs_39 IN (30,31,14))
+                NOT (cs_39_outcome_14_30_31 <=> 39 OR (outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14)))
                 AND ftpaFirstDecision IS NULL
             )
             OR
@@ -76,25 +76,25 @@ class ftpaDecidedDQRules(DQRulesBase):
             (
                 (
                     (
-                        (cs_39_46_outcome_30_31_14 = 39 AND outcome_14_30_31_cs_39_46 IN (30,31,14))
+                        (cs_39_46_outcome_30_31_14 <=> 39 AND outcome_14_30_31_cs_39_46 IS NOT NULL AND outcome_14_30_31_cs_39_46 IN (30,31,14))
                         OR
-                        (cs_39_46_outcome_30_31_14 = 46 AND outcome_14_30_31_cs_39_46 = 31)
+                        (cs_39_46_outcome_30_31_14 <=> 46 AND outcome_14_30_31_cs_39_46 <=> 31)
                     )
                     AND
                     (
-                        (outcome_14_30_31_cs_39_46 = 30 AND ftpaFinalDecisionForDisplay = 'granted')
+                        (outcome_14_30_31_cs_39_46 <=> 30 AND ftpaFinalDecisionForDisplay <=> 'granted')
                         OR
-                        (outcome_14_30_31_cs_39_46 = 31 AND ftpaFinalDecisionForDisplay = 'refused')
+                        (outcome_14_30_31_cs_39_46 <=> 31 AND ftpaFinalDecisionForDisplay <=> 'refused')
                         OR
-                        (outcome_14_30_31_cs_39_46 = 14 AND ftpaFinalDecisionForDisplay = 'notAdmitted')
+                        (outcome_14_30_31_cs_39_46 <=> 14 AND ftpaFinalDecisionForDisplay <=> 'notAdmitted')
                     )
                 )
                 OR
                 (
                     NOT (
-                        (cs_39_46_outcome_30_31_14 = 39 OR outcome_14_30_31_cs_39_46 IN (30,31,14))
+                        (cs_39_46_outcome_30_31_14 <=> 39 OR (outcome_14_30_31_cs_39_46 IS NOT NULL AND outcome_14_30_31_cs_39_46 IN (30,31,14)))
                         OR
-                        (cs_39_46_outcome_30_31_14 = 46 OR outcome_14_30_31_cs_39_46 = 31)
+                        (cs_39_46_outcome_30_31_14 <=> 46 OR outcome_14_30_31_cs_39_46 <=> 31)
                     )
                     AND ftpaFinalDecisionForDisplay IS NULL
                 )
@@ -110,19 +110,19 @@ class ftpaDecidedDQRules(DQRulesBase):
         """
         (
             (
-                (cs_39_outcome_14_30_31 = 39 AND outcome_14_30_31_cs_39 IN (30,31,14))
+                (cs_39_outcome_14_30_31 <=> 39 AND outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14))
                 AND
                 (
-                    (cs39_party_14_30_31 = 1 AND ftpaAppellantDecisionDate IS NOT NULL)
+                    (cs39_party_14_30_31 <=> 1 AND ftpaAppellantDecisionDate IS NOT NULL)
                     OR
-                    (cs39_party_14_30_31 <> 1 AND ftpaAppellantDecisionDate IS NULL)
+                    (NOT (cs39_party_14_30_31 <=> 1) AND ftpaAppellantDecisionDate IS NULL)
                     OR
                     (cs39_party_14_30_31 IS NULL AND ftpaAppellantDecisionDate IS NULL)
                 )
             )
             OR
             (
-                NOT (cs_39_outcome_14_30_31 = 39 OR outcome_14_30_31_cs_39 IN (30,31,14))
+                NOT (cs_39_outcome_14_30_31 <=> 39 OR (outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14)))
                 AND ftpaAppellantDecisionDate IS NULL
             )
             OR
@@ -137,19 +137,19 @@ class ftpaDecidedDQRules(DQRulesBase):
         """
         (
             (
-                (cs_39_outcome_14_30_31 = 39 AND outcome_14_30_31_cs_39 IN (30,31,14))
+                (cs_39_outcome_14_30_31 <=> 39 AND outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14))
                 AND
                 (
-                    (cs39_party_14_30_31 = 2 AND ftpaRespondentDecisionDate IS NOT NULL)
+                    (cs39_party_14_30_31 <=> 2 AND ftpaRespondentDecisionDate IS NOT NULL)
                     OR
-                    (cs39_party_14_30_31 <> 2 AND ftpaRespondentDecisionDate IS NULL)
+                    (NOT (cs39_party_14_30_31 <=> 2) AND ftpaRespondentDecisionDate IS NULL)
                     OR
                     (cs39_party_14_30_31 IS NULL AND ftpaRespondentDecisionDate IS NULL)
                 )
             )
             OR
             (
-                NOT (cs_39_outcome_14_30_31 = 39 OR outcome_14_30_31_cs_39 IN (30,31,14))
+                NOT (cs_39_outcome_14_30_31 <=> 39 OR (outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14)))
                 AND ftpaRespondentDecisionDate IS NULL
             )
             OR
@@ -165,21 +165,21 @@ class ftpaDecidedDQRules(DQRulesBase):
             (
                 (
                     (
-                        (cs_39_outcome_14_30_31 = 39 AND outcome_14_30_31_cs_39 IN (30,31,14))
+                        (cs_39_outcome_14_30_31 <=> 39 AND outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14))
                     )
                     AND
                     (
-                        (outcome_14_30_31_cs_39 = 30 AND cs39_party_14_30_31 = 1 AND ftpaAppellantRjDecisionOutcomeType = 'granted')
+                        (outcome_14_30_31_cs_39 <=> 30 AND cs39_party_14_30_31 <=> 1 AND ftpaAppellantRjDecisionOutcomeType <=> 'granted')
                         OR
-                        (outcome_14_30_31_cs_39 = 31 AND cs39_party_14_30_31 = 1 AND ftpaAppellantRjDecisionOutcomeType = 'refused')
+                        (outcome_14_30_31_cs_39 <=> 31 AND cs39_party_14_30_31 <=> 1 AND ftpaAppellantRjDecisionOutcomeType <=> 'refused')
                         OR
-                        (outcome_14_30_31_cs_39 = 14 AND cs39_party_14_30_31 = 1 AND ftpaAppellantRjDecisionOutcomeType = 'notAdmitted')
+                        (outcome_14_30_31_cs_39 <=> 14 AND cs39_party_14_30_31 <=> 1 AND ftpaAppellantRjDecisionOutcomeType <=> 'notAdmitted')
                     )
                 )
                 OR
                 (
                     NOT (
-                        (cs_39_outcome_14_30_31 = 39 AND outcome_14_30_31_cs_39 IN (30,31,14) AND cs39_party_14_30_31 = 1)
+                        (cs_39_outcome_14_30_31 <=> 39 AND outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14) AND cs39_party_14_30_31 <=> 1)
                     )
                     AND ftpaAppellantRjDecisionOutcomeType IS NULL
                 )
@@ -196,21 +196,21 @@ class ftpaDecidedDQRules(DQRulesBase):
             (
                 (
                     (
-                        (cs_39_outcome_14_30_31 = 39 AND outcome_14_30_31_cs_39 IN (30,31,14))
+                        (cs_39_outcome_14_30_31 <=> 39 AND outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14))
                     )
                     AND
                     (
-                        (outcome_14_30_31_cs_39 = 30 AND cs39_party_14_30_31 = 2 AND ftpaRespondentRjDecisionOutcomeType = 'granted')
+                        (outcome_14_30_31_cs_39 <=> 30 AND cs39_party_14_30_31 <=> 2 AND ftpaRespondentRjDecisionOutcomeType <=> 'granted')
                         OR
-                        (outcome_14_30_31_cs_39 = 31 AND cs39_party_14_30_31 = 2 AND ftpaRespondentRjDecisionOutcomeType = 'refused')
+                        (outcome_14_30_31_cs_39 <=> 31 AND cs39_party_14_30_31 <=> 2 AND ftpaRespondentRjDecisionOutcomeType <=> 'refused')
                         OR
-                        (outcome_14_30_31_cs_39 = 14 AND cs39_party_14_30_31 = 2 AND ftpaRespondentRjDecisionOutcomeType = 'notAdmitted')
+                        (outcome_14_30_31_cs_39 <=> 14 AND cs39_party_14_30_31 <=> 2 AND ftpaRespondentRjDecisionOutcomeType <=> 'notAdmitted')
                     )
                 )
                 OR
                 (
                     NOT (
-                        (cs_39_outcome_14_30_31 = 39 AND outcome_14_30_31_cs_39 IN (30,31,14) AND cs39_party_14_30_31 = 2)
+                        (cs_39_outcome_14_30_31 <=> 39 AND outcome_14_30_31_cs_39 IS NOT NULL AND outcome_14_30_31_cs_39 IN (30,31,14) AND cs39_party_14_30_31 <=> 2)
                     )
                     AND ftpaRespondentRjDecisionOutcomeType IS NULL
                 )
@@ -226,19 +226,19 @@ class ftpaDecidedDQRules(DQRulesBase):
         """
         (
             (
-                (dq_cs39_status = 39)
+                (dq_cs39_status <=> 39)
                 AND
                 (
-                    (dq_cs39_party = 1 AND isFtpaAppellantNoticeOfDecisionSetAside = "No")
+                    (dq_cs39_party <=> 1 AND isFtpaAppellantNoticeOfDecisionSetAside <=> "No")
                     OR
-                    (dq_cs39_party <> 1 AND isFtpaAppellantNoticeOfDecisionSetAside IS NULL)
+                    (NOT (dq_cs39_party <=> 1) AND isFtpaAppellantNoticeOfDecisionSetAside IS NULL)
                     OR
                     (dq_cs39_party IS NULL AND isFtpaAppellantNoticeOfDecisionSetAside IS NULL)
                 )
             )
             OR
             (
-                NOT (dq_cs39_status = 39)
+                NOT (dq_cs39_status <=> 39)
                 AND isFtpaAppellantNoticeOfDecisionSetAside IS NULL
             )
             OR
@@ -253,19 +253,19 @@ class ftpaDecidedDQRules(DQRulesBase):
         """
         (
             (
-                (dq_cs39_status = 39)
+                (dq_cs39_status <=> 39)
                 AND
                 (
-                    (dq_cs39_party = 2 AND isFtpaRespondentNoticeOfDecisionSetAside = "No")
+                    (dq_cs39_party <=> 2 AND isFtpaRespondentNoticeOfDecisionSetAside <=> "No")
                     OR
-                    (dq_cs39_party <> 2 AND isFtpaRespondentNoticeOfDecisionSetAside IS NULL)
+                    (NOT (dq_cs39_party <=> 2) AND isFtpaRespondentNoticeOfDecisionSetAside IS NULL)
                     OR
                     (dq_cs39_party IS NULL AND isFtpaRespondentNoticeOfDecisionSetAside IS NULL)
                 )
             )
             OR
             (
-                NOT (dq_cs39_status = 39)
+                NOT (dq_cs39_status <=> 39)
                 AND isFtpaRespondentNoticeOfDecisionSetAside IS NULL
             )
             OR
@@ -281,19 +281,19 @@ class ftpaDecidedDQRules(DQRulesBase):
     def get_checks_ftpaGeneral(self, checks={}):
 
         checks["valid_isAppellantFtpaDecisionvisibletoAll"] = ("""(
-            (dq_cs39_status = 39 AND Party IN (0,1) AND isAppellantFtpaDecisionvisibletoAll = "Yes")
+            (dq_cs39_status <=> 39 AND Party IS NOT NULL AND Party IN (0,1) AND isAppellantFtpaDecisionvisibletoAll <=> "Yes")
             OR
             (isAppellantFtpaDecisionvisibletoAll IS NULL)
         )""")
 
         checks["valid_isRespondentFtpaDecisionvisibletoAll"] = ("""(
-            (dq_cs39_status = 39 AND Party = 2 AND isRespondentFtpaDecisionvisibletoAll = "Yes")
+            (dq_cs39_status <=> 39 AND Party <=> 2 AND isRespondentFtpaDecisionvisibletoAll <=> "Yes")
             OR
             (isRespondentFtpaDecisionvisibletoAll IS NULL)
         )""")
 
         checks["valid_isDlrmSetAsideEnabled"] = ("""(
-            isDlrmSetAsideEnabled = "Yes"
+            isDlrmSetAsideEnabled <=> "Yes"
         )""")
 
         checks["valid_isFtpaAppellantDecided"] = ("""(
@@ -316,26 +316,15 @@ class ftpaDecidedDQRules(DQRulesBase):
         """)
 
         checks["valid_isReheardAppealEnabled"] = ("""(
-            isReheardAppealEnabled = "Yes"
+            isReheardAppealEnabled <=> "Yes"
         )""")
 
         checks["valid_secondFtpaDecisionExists"] = ("""(
-            (
-                secondFtpaDecisionExists =
-                CASE
-                    WHEN cs46_o31 = 46 AND o31_cs46 = 31 THEN 'Yes'
-                    ELSE 'No'
-                END
-            ))
-            OR
-            (
-            (cs46_o31 = 46 AND o31_cs46 = 31 AND secondFtpaDecisionExists = "Yes")
-            OR
-            (cs46_o31 != 46 OR o31_cs46 = 31 AND secondFtpaDecisionExists = "No")
-            OR
-            (cs46_o31 = 46 OR o31_cs46 != 31 AND secondFtpaDecisionExists = "No")
-            OR
-            (cs46_o31 != 46 OR o31_cs46 != 31 AND secondFtpaDecisionExists = "No")    
+            secondFtpaDecisionExists <=>
+            CASE
+                WHEN cs46_o31 = 46 AND o31_cs46 = 31 THEN 'Yes'
+                ELSE 'No'
+            END
             )
             """)
 
@@ -344,25 +333,25 @@ class ftpaDecidedDQRules(DQRulesBase):
     def get_checks_ftpaDocuments(self, checks={}):
 
         checks["valid_allFtpaAppellantDecisionDocs"] = ("""(
-            (dq_cs39_status = 39 AND Party = 1 AND size(allFtpaAppellantDecisionDocs) = 0)
+            (dq_cs39_status <=> 39 AND Party <=> 1 AND COALESCE(size(allFtpaAppellantDecisionDocs), 0) = 0)
             OR
             (allFtpaAppellantDecisionDocs IS NULL)
         )""")
 
         checks["valid_allFtpaRespondentDecisionDocs"] = ("""(
-            (dq_cs39_status = 39 AND Party = 2 AND size(allFtpaRespondentDecisionDocs) = 0)
+            (dq_cs39_status <=> 39 AND Party <=> 2 AND COALESCE(size(allFtpaRespondentDecisionDocs), 0) = 0)
             OR
             (allFtpaRespondentDecisionDocs IS NULL)
         )""")
 
         checks["valid_ftpaAppellantNoticeDocument"] = ("""(
-            (dq_cs39_status = 39 AND Party = 1 AND size(ftpaAppellantNoticeDocument) = 0)
+            (dq_cs39_status <=> 39 AND Party <=> 1 AND COALESCE(size(ftpaAppellantNoticeDocument), 0) = 0)
             OR
             (ftpaAppellantNoticeDocument IS NULL)
         )""")
 
         checks["valid_ftpaRespondentNoticeDocument"] = ("""(
-            (dq_cs39_status = 39 AND Party = 2 AND size(ftpaRespondentNoticeDocument) = 0)
+            (dq_cs39_status <=> 39 AND Party <=> 2 AND COALESCE(size(ftpaRespondentNoticeDocument), 0) = 0)
             OR
             (ftpaRespondentNoticeDocument IS NULL)
         )""")

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ftpa_submitted_a_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ftpa_submitted_a_dq_rules.py
@@ -271,7 +271,7 @@ class ftpaSubmittedADQRules(DQRulesBase):
         ####### Appellant #######
         checks["valid_ftpaAppellantApplicationDate"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN ftpaAppellantApplicationDate <=> date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd') IS NOT NULL AND ftpaAppellantApplicationDate <=> date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
                 ELSE ftpaAppellantApplicationDate IS NULL
             END
         )"""
@@ -294,7 +294,7 @@ class ftpaSubmittedADQRules(DQRulesBase):
         ####### Respondent #######
         checks["valid_ftpaRespondentApplicationDate"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN ftpaRespondentApplicationDate <=> date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd') IS NOT NULL AND ftpaRespondentApplicationDate <=> date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
                 ELSE ftpaRespondentApplicationDate IS NULL
             END
         )"""

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ftpa_submitted_a_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ftpa_submitted_a_dq_rules.py
@@ -14,56 +14,56 @@ class ftpaSubmittedADQRules(DQRulesBase):
     def get_checks_document(self, checks={}):
         checks["valid_ftpaAppellantDocuments"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN size(ftpaAppellantDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN COALESCE(size(ftpaAppellantDocuments), 0) = 0
                 ELSE ftpaAppellantDocuments IS NULL
             END
         )"""
 
         checks["valid_ftpaRespondentDocuments"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN size(ftpaRespondentDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN COALESCE(size(ftpaRespondentDocuments), 0) = 0
                 ELSE ftpaRespondentDocuments IS NULL
             END
         )"""
 
         checks["valid_ftpaAppellantGroundsDocuments"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN size(ftpaAppellantGroundsDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN COALESCE(size(ftpaAppellantGroundsDocuments), 0) = 0
                 ELSE ftpaAppellantGroundsDocuments IS NULL
             END
         )"""
 
         checks["valid_ftpaRespondentGroundsDocuments"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN size(ftpaRespondentGroundsDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN COALESCE(size(ftpaRespondentGroundsDocuments), 0) = 0
                 ELSE ftpaRespondentGroundsDocuments IS NULL
             END
         )"""
 
         checks["valid_ftpaAppellantEvidenceDocuments"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN size(ftpaAppellantEvidenceDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN COALESCE(size(ftpaAppellantEvidenceDocuments), 0) = 0
                 ELSE ftpaAppellantEvidenceDocuments IS NULL
             END
         )"""
 
         checks["valid_ftpaRespondentEvidenceDocuments"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN size(ftpaRespondentEvidenceDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN COALESCE(size(ftpaRespondentEvidenceDocuments), 0) = 0
                 ELSE ftpaRespondentEvidenceDocuments IS NULL
             END
         )"""
 
         checks["valid_ftpaAppellantOutOfTimeDocuments"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN size(ftpaAppellantOutOfTimeDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN COALESCE(size(ftpaAppellantOutOfTimeDocuments), 0) = 0
                 ELSE ftpaAppellantOutOfTimeDocuments IS NULL
             END
         )"""
 
         checks["valid_ftpaRespondentOutOfTimeDocuments"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN size(ftpaRespondentOutOfTimeDocuments) = 0
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN COALESCE(size(ftpaRespondentOutOfTimeDocuments), 0) = 0
                 ELSE ftpaRespondentOutOfTimeDocuments IS NULL
             END
         )"""
@@ -72,7 +72,7 @@ class ftpaSubmittedADQRules(DQRulesBase):
 
     def get_checks_general_default(self, checks={}):
 
-        checks["valid_isFtpaListVisible"] = ("(isFtpaListVisible = 'Yes')")
+        checks["valid_isFtpaListVisible"] = ("(isFtpaListVisible <=> 'Yes')")
 
         return checks
 
@@ -81,77 +81,77 @@ class ftpaSubmittedADQRules(DQRulesBase):
         ##### Appellant ######
         checks["valid_ftpaAppellantSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN ftpaAppellantSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN ftpaAppellantSubmitted <=> 'Yes'
                 ELSE ftpaAppellantSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantDocsVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantDocsVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantDocsVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantDocsVisibleInSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantOotDocsVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantOotDocsVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantOotDocsVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantOotDocsVisibleInSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantGroundsDocsVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantGroundsDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantGroundsDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantGroundsDocsVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantEvidenceDocsVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantEvidenceDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantEvidenceDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantEvidenceDocsVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantGroundsDocsVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantGroundsDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantGroundsDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantGroundsDocsVisibleInSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantEvidenceDocsVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantEvidenceDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN isFtpaAppellantEvidenceDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantEvidenceDocsVisibleInSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantOotExplanationVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotExplanationVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotExplanationVisibleInDecided <=> 'No'
                 ELSE isFtpaAppellantOotExplanationVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaAppellantOotExplanationVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotExplanationVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN isFtpaAppellantOotExplanationVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaAppellantOotExplanationVisibleInSubmitted IS NULL
             END
         )"""
@@ -159,77 +159,77 @@ class ftpaSubmittedADQRules(DQRulesBase):
         ##### Respondent ######
         checks["valid_ftpaRespondentSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN ftpaRespondentSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN ftpaRespondentSubmitted <=> 'Yes'
                 ELSE ftpaRespondentSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentDocsVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentDocsVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentDocsVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentDocsVisibleInSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentOotDocsVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentOotDocsVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentOotDocsVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentOotDocsVisibleInSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentGroundsDocsVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentGroundsDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentGroundsDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentGroundsDocsVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentEvidenceDocsVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentEvidenceDocsVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentEvidenceDocsVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentEvidenceDocsVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentGroundsDocsVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentGroundsDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentGroundsDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentGroundsDocsVisibleInSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentEvidenceDocsVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentEvidenceDocsVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN isFtpaRespondentEvidenceDocsVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentEvidenceDocsVisibleInSubmitted IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentOotExplanationVisibleInDecided"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotExplanationVisibleInDecided = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotExplanationVisibleInDecided <=> 'No'
                 ELSE isFtpaRespondentOotExplanationVisibleInDecided IS NULL
             END
         )"""
 
         checks["valid_isFtpaRespondentOotExplanationVisibleInSubmitted"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotExplanationVisibleInSubmitted = 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN isFtpaRespondentOotExplanationVisibleInSubmitted <=> 'Yes'
                 ELSE isFtpaRespondentOotExplanationVisibleInSubmitted IS NULL
             END
         )"""
@@ -243,24 +243,25 @@ class ftpaSubmittedADQRules(DQRulesBase):
         WHEN dq_cs39_status = 39 AND Party = 1 THEN
             ftpaList IS NOT NULL
         AND size(ftpaList) = 1
-        AND element_at(ftpaList, 1).id = '1'
-        AND lower(element_at(ftpaList, 1).value.ftpaApplicant) = 'appellant'
+        AND element_at(ftpaList, 1).id <=> '1'
+        AND lower(element_at(ftpaList, 1).value.ftpaApplicant) <=> 'appellant'
         AND element_at(ftpaList, 1).value.ftpaApplicationDate <=> ftpaAppellantApplicationDate
-        AND size(element_at(ftpaList, 1).value.ftpaGroundsDocuments) = 0
-        AND size(element_at(ftpaList, 1).value.ftpaEvidenceDocuments) = 0
-        AND size(element_at(ftpaList, 1).value.ftpaOutOfTimeDocuments) = 0
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaGroundsDocuments), 0) = 0
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaEvidenceDocuments), 0) = 0
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaOutOfTimeDocuments), 0) = 0
         AND element_at(ftpaList, 1).value.ftpaOutOfTimeExplanation <=> ftpaAppellantOutOfTimeExplanation
 
         WHEN dq_cs39_status = 39 AND Party = 2 THEN
             ftpaList IS NOT NULL
         AND size(ftpaList) = 1
-        AND element_at(ftpaList, 1).id = '1'
-        AND lower(element_at(ftpaList, 1).value.ftpaApplicant) = 'respondent'
+        AND element_at(ftpaList, 1).id <=> '1'
+        AND lower(element_at(ftpaList, 1).value.ftpaApplicant) <=> 'respondent'
         AND element_at(ftpaList, 1).value.ftpaApplicationDate <=> ftpaRespondentApplicationDate
-        AND size(element_at(ftpaList, 1).value.ftpaGroundsDocuments) = 0
-        AND size(element_at(ftpaList, 1).value.ftpaEvidenceDocuments) = 0
-        AND size(element_at(ftpaList, 1).value.ftpaOutOfTimeDocuments) = 0
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaGroundsDocuments), 0) = 0
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaEvidenceDocuments), 0) = 0
+        AND COALESCE(size(element_at(ftpaList, 1).value.ftpaOutOfTimeDocuments), 0) = 0
         AND element_at(ftpaList, 1).value.ftpaOutOfTimeExplanation <=> ftpaRespondentOutOfTimeExplanation
+        ELSE FALSE
         END
         )
         OR
@@ -270,22 +271,22 @@ class ftpaSubmittedADQRules(DQRulesBase):
         ####### Appellant #######
         checks["valid_ftpaAppellantApplicationDate"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 THEN ftpaAppellantApplicationDate = date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
+                WHEN dq_cs39_status = 39 AND Party = 1 THEN ftpaAppellantApplicationDate <=> date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
                 ELSE ftpaAppellantApplicationDate IS NULL
             END
         )"""
 
         checks["valid_ftpaAppellantSubmissionOutOfTime"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN ftpaAppellantSubmissionOutOfTime = 'Yes'
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime != 1 THEN ftpaAppellantSubmissionOutOfTime = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN ftpaAppellantSubmissionOutOfTime <=> 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime != 1 THEN ftpaAppellantSubmissionOutOfTime <=> 'No'
                 ELSE ftpaAppellantSubmissionOutOfTime IS NULL
             END
         )"""
 
         checks["valid_ftpaAppellantOutOfTimeExplanation"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN ftpaAppellantOutOfTimeExplanation = 'This is a migrated ARIA case. Please check the Documents, FTPA tab or Case Notes tab for reasons for lateness.'
+                WHEN dq_cs39_status = 39 AND Party = 1 AND OutOfTime = 1 THEN ftpaAppellantOutOfTimeExplanation <=> 'This is a migrated ARIA case. Please check the Documents, FTPA tab or Case Notes tab for reasons for lateness.'
                 ELSE ftpaAppellantOutOfTimeExplanation IS NULL
             END
         )"""
@@ -293,22 +294,22 @@ class ftpaSubmittedADQRules(DQRulesBase):
         ####### Respondent #######
         checks["valid_ftpaRespondentApplicationDate"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 THEN ftpaRespondentApplicationDate = date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
+                WHEN dq_cs39_status = 39 AND Party = 2 THEN ftpaRespondentApplicationDate <=> date_format(to_timestamp(DateReceived, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX'),'yyyy-MM-dd')
                 ELSE ftpaRespondentApplicationDate IS NULL
             END
         )"""
 
         checks["valid_ftpaRespondentSubmissionOutOfTime"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN ftpaRespondentSubmissionOutOfTime = 'Yes'
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime != 1 THEN ftpaRespondentSubmissionOutOfTime = 'No'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN ftpaRespondentSubmissionOutOfTime <=> 'Yes'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime != 1 THEN ftpaRespondentSubmissionOutOfTime <=> 'No'
                 ELSE ftpaRespondentSubmissionOutOfTime IS NULL
             END
         )"""
 
         checks["valid_ftpaRespondentOutOfTimeExplanation"] = """(
             CASE
-                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN ftpaRespondentOutOfTimeExplanation = 'This is a migrated ARIA case. Please check the Documents, FTPA tab or Case Notes tab for reasons for lateness.'
+                WHEN dq_cs39_status = 39 AND Party = 2 AND OutOfTime = 1 THEN ftpaRespondentOutOfTimeExplanation <=> 'This is a migrated ARIA case. Please check the Documents, FTPA tab or Case Notes tab for reasons for lateness.'
                 ELSE ftpaRespondentOutOfTimeExplanation IS NULL
             END
         )"""

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ftpa_submitted_b_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ftpa_submitted_b_dq_rules.py
@@ -14,7 +14,7 @@ class ftpaSubmittedBDQRules(DQRulesBase):
             """
             (
                 (
-                    dq_cs39_status = 39 AND 
+                    dq_cs39_status <=> 39 AND
                     (allocatedJudge <=> concat(Adj_Title, ' ', Adj_Forenames, ' ', Adj_Surname))
                 )
                 OR
@@ -29,7 +29,7 @@ class ftpaSubmittedBDQRules(DQRulesBase):
             """
             (
                 (
-                    dq_cs39_status = 39 AND 
+                    dq_cs39_status <=> 39 AND
                     (allocatedJudgeEdit <=> concat(Adj_Title, ' ', Adj_Forenames, ' ', Adj_Surname))
                 )
                 OR
@@ -40,6 +40,6 @@ class ftpaSubmittedBDQRules(DQRulesBase):
                 """
         )
 
-        checks["valid_judgeAllocationExists"] = ("(judgeAllocationExists = 'Yes')")
+        checks["valid_judgeAllocationExists"] = ("(judgeAllocationExists <=> 'Yes')")
 
         return checks

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/listing_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/listing_dq_rules.py
@@ -15,7 +15,7 @@ class listingDQRules(DQRulesBase):
     def get_checks_flags(self, checks={}):
         checks["valid_appellantLevelFlags"] = """
         (
-            (appellantLevelFlags IS NOT NULL)
+            (appellantLevelFlags IS NOT NULL AND appellantLevelFlags.details IS NOT NULL)
             AND
             (ARRAY_SIZE(appellantLevelFlags.details) >= 3)
             AND
@@ -47,20 +47,20 @@ class listingDQRules(DQRulesBase):
         (
             CASE
                 WHEN Detained IN (1,2,4)
-                    THEN isEvidenceFromOutsideUkOoc = 'No'
+                    THEN isEvidenceFromOutsideUkOoc <=> 'No'
 
                 WHEN dv_appellantIsInUk = true
-                    THEN isEvidenceFromOutsideUkOoc = 'No'
+                    THEN isEvidenceFromOutsideUkOoc <=> 'No'
 
                 WHEN dv_appellantIsInUk = false
                     AND Sponsor_Name IS NULL
-                    THEN isEvidenceFromOutsideUkOoc = 'No'
+                    THEN isEvidenceFromOutsideUkOoc <=> 'No'
 
                 WHEN dv_appellantIsInUk = false
                     AND Sponsor_Name IS NOT NULL
-                    THEN isEvidenceFromOutsideUkOoc = 'Yes'
+                    THEN isEvidenceFromOutsideUkOoc <=> 'Yes'
 
-                ELSE isEvidenceFromOutsideUkOoc = 'No'
+                ELSE isEvidenceFromOutsideUkOoc <=> 'No'
             END
         )
         """
@@ -70,20 +70,20 @@ class listingDQRules(DQRulesBase):
             CASE
                 WHEN Detained IN (1,2,4)
                     AND Sponsor_Name IS NOT NULL
-                    THEN isEvidenceFromOutsideUkInCountry = 'Yes'
+                    THEN isEvidenceFromOutsideUkInCountry <=> 'Yes'
 
                 WHEN dv_appellantIsInUk = true
                     AND Sponsor_Name IS NOT NULL
-                    THEN isEvidenceFromOutsideUkInCountry = 'Yes'
+                    THEN isEvidenceFromOutsideUkInCountry <=> 'Yes'
 
                 WHEN Detained NOT IN (1,2,4)
                     AND dv_appellantIsInUk = false
-                    THEN isEvidenceFromOutsideUkInCountry = 'No'
+                    THEN isEvidenceFromOutsideUkInCountry <=> 'No'
 
                 WHEN Sponsor_Name IS NULL
-                    THEN isEvidenceFromOutsideUkInCountry = 'No'
+                    THEN isEvidenceFromOutsideUkInCountry <=> 'No'
 
-                ELSE isEvidenceFromOutsideUkInCountry = 'No'
+                ELSE isEvidenceFromOutsideUkInCountry <=> 'No'
             END
         )
         """
@@ -127,7 +127,7 @@ class listingDQRules(DQRulesBase):
                 OR
                 (Interpreter <=> 2 AND isInterpreterServicesNeeded <=> 'No')
                 OR
-                (Interpreter NOT IN (1, 2) AND isInterpreterServicesNeeded <=> 'No')
+                ((Interpreter IS NULL OR Interpreter NOT IN (1, 2)) AND isInterpreterServicesNeeded <=> 'No')
             )"""
         )
 
@@ -148,13 +148,13 @@ class listingDQRules(DQRulesBase):
                         (
                             (LanguageId IS NULL OR LanguageId <=> 0)
                             OR
-                            (LanguageId IS NOT NULL AND NOT(LanguageId <=> 0) AND ARRAY_CONTAINS(appellantInterpreterLanguageCategory, valid_languageCategory))
+                            (LanguageId IS NOT NULL AND NOT(LanguageId <=> 0) AND ARRAY_CONTAINS(COALESCE(appellantInterpreterLanguageCategory, ARRAY()), valid_languageCategory))
                         )
                         AND
                         (
                             (AdditionalLanguageId IS NULL OR AdditionalLanguageId <=> 0)
                             OR
-                            (AdditionalLanguageId IS NOT NULL AND NOT(AdditionalLanguageId <=> 0) AND ARRAY_CONTAINS(appellantInterpreterLanguageCategory, valid_additionalLanguageCategory))
+                            (AdditionalLanguageId IS NOT NULL AND NOT(AdditionalLanguageId <=> 0) AND ARRAY_CONTAINS(COALESCE(appellantInterpreterLanguageCategory, ARRAY()), valid_additionalLanguageCategory))
                         )
                     )
                 END
@@ -183,17 +183,17 @@ class listingDQRules(DQRulesBase):
                                     WHEN (
                                         (valid_manualEntry <=> 'Yes')
                                     ) THEN (
-                                        (ARRAY_CONTAINS(appellantInterpreterSpokenLanguage.languageManualEntry, valid_manualEntry))
+                                        (ARRAY_CONTAINS(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntry, ARRAY()), valid_manualEntry))
                                         AND
-                                        (CONTAINS(appellantInterpreterSpokenLanguage.languageManualEntryDescription, valid_manualEntryDescription))
+                                        (CONTAINS(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntryDescription, ''), valid_manualEntryDescription))
                                         AND
                                         (appellantInterpreterSpokenLanguage.languageRefData IS NULL)
                                     ) WHEN (
                                         ((NOT(valid_manualEntry <=> 'Yes')) AND (valid_additionalLanguageCategory <=> 'spokenLanguageInterpreter'))
                                     ) THEN (
-                                        (ARRAY_CONTAINS(appellantInterpreterSpokenLanguage.languageManualEntry, 'Yes'))
+                                        (ARRAY_CONTAINS(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntry, ARRAY()), 'Yes'))
                                         AND
-                                        (CONTAINS(appellantInterpreterSpokenLanguage.languageManualEntryDescription, valid_languageLabel))
+                                        (CONTAINS(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntryDescription, ''), valid_languageLabel))
                                         AND
                                         (appellantInterpreterSpokenLanguage.languageRefData IS NULL)
                                     ) ELSE (
@@ -201,7 +201,7 @@ class listingDQRules(DQRulesBase):
                                         AND
                                         (appellantInterpreterSpokenLanguage.languageRefData.value.label <=> valid_languageLabel)
                                         AND
-                                        (ARRAY_SIZE(appellantInterpreterSpokenLanguage.languageRefData.list_items) > 0)
+                                        (COALESCE(ARRAY_SIZE(appellantInterpreterSpokenLanguage.languageRefData.list_items), 0) > 0)
                                         AND
                                         (ARRAY_SIZE(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntry, ARRAY())) <=> 0)
                                         AND
@@ -219,17 +219,17 @@ class listingDQRules(DQRulesBase):
                                     WHEN (
                                         (valid_additionalManualEntry <=> 'Yes')
                                     ) THEN (
-                                        (ARRAY_CONTAINS(appellantInterpreterSpokenLanguage.languageManualEntry, valid_additionalManualEntry))
+                                        (ARRAY_CONTAINS(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntry, ARRAY()), valid_additionalManualEntry))
                                         AND
-                                        (CONTAINS(appellantInterpreterSpokenLanguage.languageManualEntryDescription, valid_additionalManualEntryDescription))
+                                        (CONTAINS(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntryDescription, ''), valid_additionalManualEntryDescription))
                                         AND
                                         (appellantInterpreterSpokenLanguage.languageRefData IS NULL)
                                     ) WHEN (
                                         ((NOT(valid_additionalManualEntry <=> 'Yes')) AND (valid_languageCategory <=> 'spokenLanguageInterpreter'))
                                     ) THEN (
-                                        (ARRAY_CONTAINS(appellantInterpreterSpokenLanguage.languageManualEntry, 'Yes'))
+                                        (ARRAY_CONTAINS(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntry, ARRAY()), 'Yes'))
                                         AND
-                                        (CONTAINS(appellantInterpreterSpokenLanguage.languageManualEntryDescription, valid_additionalLanguageLabel))
+                                        (CONTAINS(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntryDescription, ''), valid_additionalLanguageLabel))
                                         AND
                                         (appellantInterpreterSpokenLanguage.languageRefData IS NULL)
                                     ) ELSE (
@@ -237,7 +237,7 @@ class listingDQRules(DQRulesBase):
                                         AND
                                         (appellantInterpreterSpokenLanguage.languageRefData.value.label <=> valid_additionalLanguageLabel)
                                         AND
-                                        (ARRAY_SIZE(appellantInterpreterSpokenLanguage.languageRefData.list_items) > 0)
+                                        (COALESCE(ARRAY_SIZE(appellantInterpreterSpokenLanguage.languageRefData.list_items), 0) > 0)
                                         AND
                                         (ARRAY_SIZE(COALESCE(appellantInterpreterSpokenLanguage.languageManualEntry, ARRAY())) <=> 0)
                                         AND
@@ -272,17 +272,17 @@ class listingDQRules(DQRulesBase):
                                     WHEN (
                                         (valid_manualEntry <=> 'Yes')
                                     ) THEN (
-                                        (ARRAY_CONTAINS(appellantInterpreterSignLanguage.languageManualEntry, valid_manualEntry))
+                                        (ARRAY_CONTAINS(COALESCE(appellantInterpreterSignLanguage.languageManualEntry, ARRAY()), valid_manualEntry))
                                         AND
-                                        (CONTAINS(appellantInterpreterSignLanguage.languageManualEntryDescription, valid_manualEntryDescription))
+                                        (CONTAINS(COALESCE(appellantInterpreterSignLanguage.languageManualEntryDescription, ''), valid_manualEntryDescription))
                                         AND
                                         (appellantInterpreterSignLanguage.languageRefData IS NULL)
                                     ) WHEN (
                                         ((NOT(valid_manualEntry <=> 'Yes')) AND (valid_additionalLanguageCategory <=> 'signLanguageInterpreter'))
                                     ) THEN (
-                                        (ARRAY_CONTAINS(appellantInterpreterSignLanguage.languageManualEntry, 'Yes'))
+                                        (ARRAY_CONTAINS(COALESCE(appellantInterpreterSignLanguage.languageManualEntry, ARRAY()), 'Yes'))
                                         AND
-                                        (CONTAINS(appellantInterpreterSignLanguage.languageManualEntryDescription, valid_languageLabel))
+                                        (CONTAINS(COALESCE(appellantInterpreterSignLanguage.languageManualEntryDescription, ''), valid_languageLabel))
                                         AND
                                         (appellantInterpreterSignLanguage.languageRefData IS NULL)
                                     ) ELSE (
@@ -290,7 +290,7 @@ class listingDQRules(DQRulesBase):
                                         AND
                                         (appellantInterpreterSignLanguage.languageRefData.value.label <=> valid_languageLabel)
                                         AND
-                                        (ARRAY_SIZE(appellantInterpreterSignLanguage.languageRefData.list_items) > 0)
+                                        (COALESCE(ARRAY_SIZE(appellantInterpreterSignLanguage.languageRefData.list_items), 0) > 0)
                                         AND
                                         (ARRAY_SIZE(COALESCE(appellantInterpreterSignLanguage.languageManualEntry, ARRAY())) <=> 0)
                                         AND
@@ -308,17 +308,17 @@ class listingDQRules(DQRulesBase):
                                     WHEN (
                                         (valid_additionalManualEntry <=> 'Yes')
                                     ) THEN (
-                                        (ARRAY_CONTAINS(appellantInterpreterSignLanguage.languageManualEntry, valid_additionalManualEntry))
+                                        (ARRAY_CONTAINS(COALESCE(appellantInterpreterSignLanguage.languageManualEntry, ARRAY()), valid_additionalManualEntry))
                                         AND
-                                        (CONTAINS(appellantInterpreterSignLanguage.languageManualEntryDescription, valid_additionalManualEntryDescription))
+                                        (CONTAINS(COALESCE(appellantInterpreterSignLanguage.languageManualEntryDescription, ''), valid_additionalManualEntryDescription))
                                         AND
                                         (appellantInterpreterSignLanguage.languageRefData IS NULL)
                                     ) WHEN (
                                         ((NOT(valid_additionalManualEntry <=> 'Yes')) AND (valid_languageCategory <=> 'signLanguageInterpreter'))
                                     ) THEN (
-                                        (ARRAY_CONTAINS(appellantInterpreterSignLanguage.languageManualEntry, 'Yes'))
+                                        (ARRAY_CONTAINS(COALESCE(appellantInterpreterSignLanguage.languageManualEntry, ARRAY()), 'Yes'))
                                         AND
-                                        (CONTAINS(appellantInterpreterSignLanguage.languageManualEntryDescription, valid_additionalLanguageLabel))
+                                        (CONTAINS(COALESCE(appellantInterpreterSignLanguage.languageManualEntryDescription, ''), valid_additionalLanguageLabel))
                                         AND
                                         (appellantInterpreterSignLanguage.languageRefData IS NULL)
                                     ) ELSE (
@@ -326,7 +326,7 @@ class listingDQRules(DQRulesBase):
                                         AND
                                         (appellantInterpreterSignLanguage.languageRefData.value.label <=> valid_additionalLanguageLabel)
                                         AND
-                                        (ARRAY_SIZE(appellantInterpreterSignLanguage.languageRefData.list_items) > 0)
+                                        (COALESCE(ARRAY_SIZE(appellantInterpreterSignLanguage.languageRefData.list_items), 0) > 0)
                                         AND
                                         (ARRAY_SIZE(COALESCE(appellantInterpreterSignLanguage.languageManualEntry, ARRAY())) <=> 0)
                                         AND
@@ -386,7 +386,7 @@ class listingDQRules(DQRulesBase):
                 OR
                 ((CourtPreference <=> 1 OR CourtPreference <=> 2) AND singleSexCourt <=> 'Yes')
                 OR
-                (CourtPreference NOT IN (0, 1, 2) AND singleSexCourt <=> 'No')
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (0, 1, 2)) AND singleSexCourt <=> 'No')
             )"""
         )
 
@@ -396,7 +396,7 @@ class listingDQRules(DQRulesBase):
                 OR
                 (CourtPreference <=> 2 AND singleSexCourtType <=> 'All female')
                 OR
-                (CourtPreference NOT IN (1, 2) AND singleSexCourtType IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND singleSexCourtType IS NULL)
             )"""
         )
 
@@ -404,7 +404,7 @@ class listingDQRules(DQRulesBase):
             """(
                 ((CourtPreference <=> 1 OR CourtPreference <=> 2) AND singleSexCourtTypeDescription <=> 'This is an ARIA migrated case. Please refer to the hearing requirements in the appeal form for further details on the single sex court.')
                 OR
-                (CourtPreference NOT IN (1, 2) AND singleSexCourtTypeDescription IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND singleSexCourtTypeDescription IS NULL)
             )"""
         )
 
@@ -473,7 +473,7 @@ class listingDQRules(DQRulesBase):
         )
 
         checks["valid_reviewedHearingRequirements"] = ("""
-            (reviewedHearingRequirements IN ('Yes','No'))
+            (reviewedHearingRequirements IS NOT NULL AND reviewedHearingRequirements IN ('Yes','No'))
         """)
 
         checks["valid_amendResponseActionAvailable"] = (

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpendingDetained_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpendingDetained_dq_rules.py
@@ -17,13 +17,13 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_appellantInDetention"] = (
             """
             (
-                Detained IN (1,2,4)
-                AND appellantInDetention = 'Yes'
+                Detained IS NOT NULL AND Detained IN (1,2,4)
+                AND appellantInDetention <=> 'Yes'
             )
             OR
             (
-                Detained NOT IN (1,2,4)
-                AND appellantInDetention = 'No'
+                (Detained IS NULL OR Detained NOT IN (1,2,4))
+                AND appellantInDetention <=> 'No'
             )
             """
         )
@@ -31,43 +31,43 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_detentionFacility"] = (
             """
             (
-                Detained = 1
-                AND detentionFacility = 'prison'
+                Detained <=> 1
+                AND detentionFacility <=> 'prison'
             )
             OR
             (
-                Detained = 2
-                AND detentionFacility = 'immigrationRemovalCentre'
+                Detained <=> 2
+                AND detentionFacility <=> 'immigrationRemovalCentre'
             )
             OR
             (
-                Detained = 4
-                AND detentionFacility = 'other'
+                Detained <=> 4
+                AND detentionFacility <=> 'other'
             )
             OR
             (
-                Detained NOT IN (1,2,4)
+                (Detained IS NULL OR Detained NOT IN (1,2,4))
                 AND detentionFacility IS NULL
             )
             """
         )
-        
+
         checks["valid_prisonName"] = (
-            """ ( Detained != 1 AND  prisonName IS NULL) OR 
+            """ ( NOT(Detained <=> 1) AND  prisonName IS NULL) OR
                 ( prisonName <=> prisonName_det )
-            
+
             """)
-        
+
         checks["valid_prisonNOMSNumber"] = (
             """
             (
-                (Detained != 1 OR PrisonRef IS NULL)
+                (NOT(Detained <=> 1) OR PrisonRef IS NULL)
                 AND prisonNOMSNumber IS NULL
-            ) 
-            OR 
+            )
+            OR
             (
-                Detained = 1 
-                AND PrisonRef IS NOT NULL 
+                Detained <=> 1
+                AND PrisonRef IS NOT NULL
                 AND prisonNOMSNumber.prison <=> PrisonRef
             )
             """
@@ -76,69 +76,69 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_otherDetentionFacilityName"] = (
             """
             (
-                (Detained != 4)
+                NOT(Detained <=> 4)
                 AND otherDetentionFacilityName IS NULL
             )
             OR
             (
-                Detained = 4
+                Detained <=> 4
                 AND otherDetentionFacilityName.other <=> coalesce(DetentionCentre_det, Appellant_Address1)
             )
             """
         )
-        
+
         checks["valid_ircName"] = (
             """
             (
-                (Detained != 2)
+                NOT(Detained <=> 2)
                 AND ircName IS NULL
             )
             OR
             (
-                Detained = 2
+                Detained <=> 2
                 AND ircName <=> ircName_det
             )
             """
         )
-        
+
         checks["valid_releaseDateProvided"] = (
             """
             (
-                (Detained NOT IN (1,4))
+                (Detained IS NULL OR Detained NOT IN (1,4))
                 AND releaseDateProvided IS NULL
             )
             OR
             (
-                Detained IN (1,4)
-                AND releaseDateProvided = 'Yes'
+                Detained IS NOT NULL AND Detained IN (1,4)
+                AND releaseDateProvided <=> 'Yes'
             )
             """
         )
-        
+
         checks["valid_hasPendingBailApplications"] = (
             """
             (
-                (Detained != 2)
+                NOT(Detained <=> 2)
                 AND hasPendingBailApplications IS NULL
             )
             OR
             (
-                Detained = 2
-                AND hasPendingBailApplications = 'NotSure'
+                Detained <=> 2
+                AND hasPendingBailApplications <=> 'NotSure'
             )
             """
         )
-        
+
         checks["valid_removalOrderOptions"] = (
             """
             (
                 RemovalDate IS NOT NULL
-                AND removalOrderOptions = 'Yes'
+                AND removalOrderOptions <=> 'Yes'
             )
             OR
             (
                 RemovalDate IS NULL
-                AND removalOrderOptions = 'No'
+                AND removalOrderOptions <=> 'No'
             )
             """
         )
@@ -152,7 +152,7 @@ class paymentPendingDetainedDQRules(DQRulesBase):
             OR
             (
                 RemovalDate IS NOT NULL
-                AND removalOrderDate = date_format(RemovalDate, "yyyy-MM-dd'T'HH:mm:ss.SSS")
+                AND removalOrderDate <=> date_format(RemovalDate, "yyyy-MM-dd'T'HH:mm:ss.SSS")
             )
             """
         )
@@ -160,12 +160,12 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_detentionBuilding"] = (
             """
             (
-                (Detained NOT IN (1,2))
+                (Detained IS NULL OR Detained NOT IN (1,2))
                 AND detentionBuilding IS NULL
             )
             OR
             (
-                Detained IN (1,2)
+                Detained IS NOT NULL AND Detained IN (1,2)
                 AND detentionBuilding <=> detentionBuilding_det
             )
             """
@@ -174,12 +174,12 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_detentionAddressLines"] = (
             """
             (
-                (Detained NOT IN (1,2))
+                (Detained IS NULL OR Detained NOT IN (1,2))
                 AND detentionAddressLines IS NULL
             )
             OR
             (
-                Detained IN (1,2)
+                Detained IS NOT NULL AND Detained IN (1,2)
                 AND detentionAddressLines <=> detentionAddressLines_det
             )
             """
@@ -188,12 +188,12 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_detentionPostcode"] = (
             """
             (
-                (Detained NOT IN (1,2))
+                (Detained IS NULL OR Detained NOT IN (1,2))
                 AND detentionPostcode IS NULL
             )
             OR
             (
-                Detained IN (1,2)
+                Detained IS NOT NULL AND Detained IN (1,2)
                 AND detentionPostcode <=> detentionPostcode_det
             )
             """
@@ -207,10 +207,10 @@ class paymentPendingDetainedDQRules(DQRulesBase):
             (
                 CASE
                     WHEN Sponsor_Name IS NOT NULL
-                    THEN hasSponsor = 'Yes'
+                    THEN hasSponsor <=> 'Yes'
 
                     WHEN Sponsor_Name IS NULL
-                    THEN hasSponsor = 'No'
+                    THEN hasSponsor <=> 'No'
                 END
             )
             """
@@ -243,7 +243,7 @@ class paymentPendingDetainedDQRules(DQRulesBase):
             (
                 CASE
                     WHEN Sponsor_Name IS NOT NULL
-                    THEN sponsorAuthorisation IN ('Yes', 'No')
+                    THEN sponsorAuthorisation IS NOT NULL AND sponsorAuthorisation IN ('Yes', 'No')
 
                     WHEN Sponsor_Name IS NULL
                     THEN sponsorAuthorisation IS NULL
@@ -330,10 +330,10 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_applicationChangeDesignatedHearingCentre_fixed_list"] = (
             """(
                 CASE
-                    WHEN Detained IN (1,2) THEN applicationChangeDesignatedHearingCentre IN ('taylorHouse','hattonCross','birmingham','glasgow','manchester',
+                    WHEN Detained IN (1,2) THEN applicationChangeDesignatedHearingCentre IS NOT NULL AND applicationChangeDesignatedHearingCentre IN ('taylorHouse','hattonCross','birmingham','glasgow','manchester',
                     'newcastle','bradford','newport','yarlsWood')
                     ELSE
-                    applicationChangeDesignatedHearingCentre IN ('taylorHouse', 'newport', 'newcastle', 'manchester', 'hattonCross' ,'glasgow' ,'bradford' ,'birmingham', 'arnhemHouse', 'crownHouse', 'harmondsworth', 'yarlsWood', 'remoteHearing', 'decisionWithoutHearing')
+                    applicationChangeDesignatedHearingCentre IS NOT NULL AND applicationChangeDesignatedHearingCentre IN ('taylorHouse', 'newport', 'newcastle', 'manchester', 'hattonCross' ,'glasgow' ,'bradford' ,'birmingham', 'arnhemHouse', 'crownHouse', 'harmondsworth', 'yarlsWood', 'remoteHearing', 'decisionWithoutHearing')
                 END
             )"""
         )
@@ -370,9 +370,10 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_caseManagementLocation_region_and_baseLocation"] = ("""
         (
             CASE 
-                    WHEN Detained IN (1,2)  
-                        THEN    caseManagementLocation.region <=> '1' 
+                    WHEN Detained IN (1,2)
+                        THEN    caseManagementLocation.region <=> '1'
                                 AND
+                                caseManagementLocation.baseLocation IS NOT NULL AND
                                 caseManagementLocation.baseLocation IN ('227101','231596','366559','366796','386417','512401','512401','649000','698118','765324')
 
                     ELSE        caseManagementLocation.region <=> '1' AND
@@ -388,8 +389,8 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_hearingCentreDynamicList_code_in_list_items"] = ("""
         (
             CASE 
-                    WHEN Detained IN (1,2)  
-                        THEN hearingCentreDynamicList.value.code IN ('765324','386417','231596','366559','512401','366796','698118','227101','649000')
+                    WHEN Detained IN (1,2)
+                        THEN hearingCentreDynamicList.value.code IS NOT NULL AND hearingCentreDynamicList.value.code IN ('765324','386417','231596','366559','512401','366796','698118','227101','649000')
 
                     ELSE hearingCentreDynamicList.value.code IS NOT NULL AND
                                 hearingCentreDynamicList.value.code IN (
@@ -402,8 +403,8 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_hearingCentreDynamicList_label_in_list_items"] = ("""
         (
             CASE 
-                    WHEN Detained IN (1,2)  
-                        THEN hearingCentreDynamicList.value.label IN ('Taylor House Tribunal Hearing Centre','Hatton Cross Tribunal Hearing Centre','Birmingham Civil And Family Justice Centre','Atlantic Quay - Glasgow','Manchester Tribunal Hearing Centre - Piccadilly Exchange','Newcastle Civil And Family Courts And Tribunals Centre','Bradford Tribunal Hearing Centre','Newport Tribunal Centre - Columbus House','Yarls Wood Immigration And Asylum Hearing Centre')
+                    WHEN Detained IN (1,2)
+                        THEN hearingCentreDynamicList.value.label IS NOT NULL AND hearingCentreDynamicList.value.label IN ('Taylor House Tribunal Hearing Centre','Hatton Cross Tribunal Hearing Centre','Birmingham Civil And Family Justice Centre','Atlantic Quay - Glasgow','Manchester Tribunal Hearing Centre - Piccadilly Exchange','Newcastle Civil And Family Courts And Tribunals Centre','Bradford Tribunal Hearing Centre','Newport Tribunal Centre - Columbus House','Yarls Wood Immigration And Asylum Hearing Centre')
 
                     ELSE hearingCentreDynamicList.value.label IS NOT NULL AND
                                 hearingCentreDynamicList.value.label  IN (
@@ -417,8 +418,8 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_caseManagementLocationRefData_code_in_list_items"] = ("""
         (
             CASE 
-                    WHEN Detained IN (1,2)  
-                        THEN caseManagementLocationRefData.baseLocation.value.code IN ('765324','386417','231596','366559','512401','366796','698118','227101','649000')
+                    WHEN Detained IN (1,2)
+                        THEN caseManagementLocationRefData.baseLocation.value.code IS NOT NULL AND caseManagementLocationRefData.baseLocation.value.code IN ('765324','386417','231596','366559','512401','366796','698118','227101','649000')
 
                     ELSE caseManagementLocationRefData.baseLocation.value.code IS NOT NULL AND
                                 caseManagementLocationRefData.baseLocation.value.code IN (
@@ -432,8 +433,8 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         (
             
             CASE 
-                    WHEN Detained IN (1,2)  
-                        THEN caseManagementLocationRefData.baseLocation.value.label IN ('Taylor House Tribunal Hearing Centre','Hatton Cross Tribunal Hearing Centre','Birmingham Civil And Family Justice Centre','Atlantic Quay - Glasgow','Manchester Tribunal Hearing Centre - Piccadilly Exchange','Newcastle Civil And Family Courts And Tribunals Centre','Bradford Tribunal Hearing Centre','Newport Tribunal Centre - Columbus House','Yarls Wood Immigration And Asylum Hearing Centre')
+                    WHEN Detained IN (1,2)
+                        THEN caseManagementLocationRefData.baseLocation.value.label IS NOT NULL AND caseManagementLocationRefData.baseLocation.value.label IN ('Taylor House Tribunal Hearing Centre','Hatton Cross Tribunal Hearing Centre','Birmingham Civil And Family Justice Centre','Atlantic Quay - Glasgow','Manchester Tribunal Hearing Centre - Piccadilly Exchange','Newcastle Civil And Family Courts And Tribunals Centre','Bradford Tribunal Hearing Centre','Newport Tribunal Centre - Columbus House','Yarls Wood Immigration And Asylum Hearing Centre')
 
                     ELSE caseManagementLocationRefData.baseLocation.value.label IS NOT NULL AND
                                 caseManagementLocationRefData.baseLocation.value.label IN (
@@ -447,15 +448,15 @@ class paymentPendingDetainedDQRules(DQRulesBase):
 
         checks["valid_selectedHearingCentreRefData_not_null"] = ("""
                                                                  
-                        CASE 
-                            WHEN Detained IN (1,2) THEN 
-                            selectedHearingCentreRefData IN ('Atlantic Quay - Glasgow','Birmingham Civil And Family Justice Centre',
+                        CASE
+                            WHEN Detained IN (1,2) THEN
+                            selectedHearingCentreRefData IS NOT NULL AND selectedHearingCentreRefData IN ('Atlantic Quay - Glasgow','Birmingham Civil And Family Justice Centre',
                             'Bradford Tribunal Hearing Centre','Hatton Cross Tribunal Hearing Centre','Manchester Tribunal Hearing Centre - Piccadilly Exchange',
                             'Newcastle Civil And Family Courts And Tribunals Centre','Newport Tribunal Centre - Columbus House','Taylor House Tribunal Hearing Centre',
                             'Yarls Wood Immigration And Asylum Hearing Centre')
 
                             ELSE
-                            selectedHearingCentreRefData IN ('Atlantic Quay - Glasgow','Birmingham Civil And Family Justice Centre','Bradford Tribunal Hearing Centre',
+                            selectedHearingCentreRefData IS NOT NULL AND selectedHearingCentreRefData IN ('Atlantic Quay - Glasgow','Birmingham Civil And Family Justice Centre','Bradford Tribunal Hearing Centre',
                             'Hatton Cross Tribunal Hearing Centre','Manchester Tribunal Hearing Centre - Piccadilly Exchange','Harmondsworth Tribunal Hearing Centre',
                             'Newcastle Civil And Family Courts And Tribunals Centre','Newport Tribunal Centre - Columbus House','Taylor House Tribunal Hearing Centre',
                             'Yarls Wood Immigration And Asylum Hearing Centre')
@@ -468,17 +469,17 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         # ##############################
 
         checks["valid_appellantInUk"] = ("""
-            CASE    WHEN Detained IN (1,2,4) THEN appellantInUk = 'Yes'
-                    WHEN array_contains(valid_categoryIdList, 37) THEN appellantInUk = 'Yes'
-                    WHEN array_contains(valid_categoryIdList, 38) THEN appellantInUk = 'No'
-                    WHEN dv_addressInUk THEN appellantInUk = 'Yes'
-                    ELSE appellantInUk = 'No'
+            CASE    WHEN Detained IN (1,2,4) THEN appellantInUk <=> 'Yes'
+                    WHEN array_contains(valid_categoryIdList, 37) THEN appellantInUk <=> 'Yes'
+                    WHEN array_contains(valid_categoryIdList, 38) THEN appellantInUk <=> 'No'
+                    WHEN dv_addressInUk THEN appellantInUk <=> 'Yes'
+                    ELSE appellantInUk <=> 'No'
             END
         """)
 
         checks["valid_appealOutOfCountry"] = ("""
-            CASE    WHEN appellantInUk = 'Yes' THEN appealOutOfCountry = 'No'
-                    WHEN appellantInUk = 'No' THEN appealOutOfCountry = 'Yes'
+            CASE    WHEN appellantInUk = 'Yes' THEN appealOutOfCountry <=> 'No'
+                    WHEN appellantInUk = 'No' THEN appealOutOfCountry <=> 'Yes'
                     ELSE appealOutOfCountry IS NULL
             END
         """)
@@ -490,68 +491,69 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         # Only include if CategoryIdList contains 37; check for 'Yes'
         checks["valid_appellantHasFixedAddress_yes_no_if_cat37"] = ("""
                                                                     
-            CASE    WHEN Detained IN (1,2) THEN appellantHasFixedAddress IS NULL 
-                    WHEN array_contains(valid_categoryIdList, 37) THEN appellantHasFixedAddress = 'Yes'
+            CASE    WHEN Detained IN (1,2) THEN appellantHasFixedAddress IS NULL
+                    WHEN array_contains(valid_categoryIdList, 37) THEN appellantHasFixedAddress <=> 'Yes'
                     ELSE appellantHasFixedAddress IS NULL
             END
         """)
 
-        # Only include if array_contains(valid_categoryIdList, 37)
+        # Only include if array_contains(COALESCE(valid_categoryIdList, ARRAY()), 37)
         checks["valid_appellantAddress_AddressLine1_mandatory_and_length"] = ("""
             CASE 
                 WHEN Detained IN (1,2) THEN appellantAddress IS NULL
                 ELSE
-                (array_contains(valid_categoryIdList, 37) AND appellantAddress.AddressLine1 IS NOT NULL AND LENGTH(appellantAddress.AddressLine1) <= 150) OR (appellantAddress.AddressLine1 IS NULL) 
+                (array_contains(COALESCE(valid_categoryIdList, ARRAY()), 37) AND appellantAddress.AddressLine1 IS NOT NULL AND LENGTH(appellantAddress.AddressLine1) <= 150) OR (appellantAddress.AddressLine1 IS NULL) 
             END
         """)
         checks["valid_appellantAddress_AddressLine2_length"] = ("""
             CASE 
                 WHEN Detained IN (1,2) THEN appellantAddress IS NULL
                 ELSE                                                 
-                 (array_contains(valid_categoryIdList, 37) AND (appellantAddress.AddressLine2 IS NULL OR LENGTH(appellantAddress.AddressLine2) <= 50)) OR ( appellantAddress.AddressLine2 IS NULL)
+                 (array_contains(COALESCE(valid_categoryIdList, ARRAY()), 37) AND (appellantAddress.AddressLine2 IS NULL OR LENGTH(appellantAddress.AddressLine2) <= 50)) OR ( appellantAddress.AddressLine2 IS NULL)
             END
         """)
         checks["valid_appellantAddress_AddressLine3_length"] = ("""
             CASE 
                 WHEN Detained IN (1,2) THEN appellantAddress IS NULL
                 ELSE 
-                    (array_contains(valid_categoryIdList, 37) AND (appellantAddress.AddressLine3 IS NULL OR LENGTH(appellantAddress.AddressLine3) <= 50)) OR (appellantAddress.AddressLine3 IS NULL)
+                    (array_contains(COALESCE(valid_categoryIdList, ARRAY()), 37) AND (appellantAddress.AddressLine3 IS NULL OR LENGTH(appellantAddress.AddressLine3) <= 50)) OR (appellantAddress.AddressLine3 IS NULL)
             END
         """)
         checks["valid_appellantAddress_PostTown_length"] = ("""
             CASE 
                 WHEN Detained IN (1,2) THEN appellantAddress IS NULL
                 ELSE 
-                    (array_contains(valid_categoryIdList, 37) AND (appellantAddress.PostTown IS NULL OR LENGTH(appellantAddress.PostTown) <= 50)) OR (appellantAddress.PostTown IS NULL)
+                    (array_contains(COALESCE(valid_categoryIdList, ARRAY()), 37) AND (appellantAddress.PostTown IS NULL OR LENGTH(appellantAddress.PostTown) <= 50)) OR (appellantAddress.PostTown IS NULL)
             END
         """)
         checks["valid_appellantAddress_County_length"] = ("""
             CASE 
                 WHEN Detained IN (1,2) THEN appellantAddress IS NULL
                 ELSE 
-                    (array_contains(valid_categoryIdList, 37) AND (appellantAddress.County IS NULL OR LENGTH(appellantAddress.County) <= 50)) OR (appellantAddress.County IS NULL)
+                    (array_contains(COALESCE(valid_categoryIdList, ARRAY()), 37) AND (appellantAddress.County IS NULL OR LENGTH(appellantAddress.County) <= 50)) OR (appellantAddress.County IS NULL)
             END
         """)
         checks["valid_appellantAddress_PostCode_length"] = ("""
             CASE 
                 WHEN Detained IN (1,2) THEN appellantAddress IS NULL
                 ELSE                                                
-                    (array_contains(valid_categoryIdList, 37) AND (appellantAddress.PostCode IS NULL OR LENGTH(appellantAddress.PostCode) <= 14)) OR (appellantAddress.PostCode IS NULL)
+                    (array_contains(COALESCE(valid_categoryIdList, ARRAY()), 37) AND (appellantAddress.PostCode IS NULL OR LENGTH(appellantAddress.PostCode) <= 14)) OR (appellantAddress.PostCode IS NULL)
             END
         """)
         checks["valid_appellantAddress_Country_length"] = ("""
             CASE 
                 WHEN Detained IN (1,2) THEN appellantAddress IS NULL
                 ELSE 
-                    (array_contains(valid_categoryIdList, 37) AND (appellantAddress.Country IS NULL OR LENGTH(appellantAddress.Country) <= 50)) OR (appellantAddress.Country IS NULL)
+                    (array_contains(COALESCE(valid_categoryIdList, ARRAY()), 37) AND (appellantAddress.Country IS NULL OR LENGTH(appellantAddress.Country) <= 50)) OR (appellantAddress.Country IS NULL)
             END
         """)
 
         checks["valid_TTL"] = ("""
             (
-                TTL.Suspended = 'No'
+                TTL.Suspended <=> 'No'
                 AND
-                TTL.SystemTTL = date_format(date_add(DateLodged, 36524),'yyyy-MM-dd')
+                date_format(date_add(DateLodged, 36524),'yyyy-MM-dd') IS NOT NULL
+                AND TTL.SystemTTL <=> date_format(date_add(DateLodged, 36524),'yyyy-MM-dd')
             )
         """)
 
@@ -564,9 +566,9 @@ class paymentPendingDetainedDQRules(DQRulesBase):
                     THEN oocAppealAdminJ IS NULL
                 WHEN dv_appellantIsInUk = FALSE
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE "%GWF%"
-                    THEN oocAppealAdminJ = "entryClearanceDecision"
+                    THEN oocAppealAdminJ <=> "entryClearanceDecision"
                 WHEN dv_appellantIsInUk = FALSE
-                    THEN oocAppealAdminJ = "none"
+                    THEN oocAppealAdminJ <=> "none"
                 ELSE oocAppealAdminJ IS NULL
             END
         )
@@ -581,7 +583,7 @@ class paymentPendingDetainedDQRules(DQRulesBase):
                     THEN appellantHasFixedAddressAdminJ IS NULL
 
                 WHEN dv_appellantIsInUk = false
-                    THEN appellantHasFixedAddressAdminJ = 'Yes'
+                    THEN appellantHasFixedAddressAdminJ <=> 'Yes'
 
                 ELSE appellantHasFixedAddressAdminJ IS NULL
             END
@@ -612,7 +614,7 @@ class paymentPendingDetainedDQRules(DQRulesBase):
                             Appellant_Address5,
                             Appellant_Postcode
                         ) IS NOT NULL
-                    THEN addressLine1AdminJ = coalesce(
+                    THEN addressLine1AdminJ <=> coalesce(
                             Appellant_Address1,
                             Appellant_Address2,
                             Appellant_Address3,
@@ -666,6 +668,8 @@ class paymentPendingDetainedDQRules(DQRulesBase):
                             AND addressLine2AdminJ IS NULL
                         )
                     )
+
+                ELSE addressLine2AdminJ IS NULL
             END
         """
 
@@ -689,7 +693,7 @@ class paymentPendingDetainedDQRules(DQRulesBase):
                         Appellant_Address3 IS NOT NULL
                         OR Appellant_Address4 IS NOT NULL
                     )
-                    THEN addressLine3AdminJ =
+                    THEN addressLine3AdminJ <=>
                         concat_ws(', ', Appellant_Address3, Appellant_Address4)
 
                 WHEN dv_appellantIsInUk = false
@@ -720,7 +724,7 @@ class paymentPendingDetainedDQRules(DQRulesBase):
                         Appellant_Address5 IS NOT NULL
                         OR Appellant_Postcode IS NOT NULL
                     )
-                    THEN addressLine4AdminJ =
+                    THEN addressLine4AdminJ <=>
                         concat_ws(', ', Appellant_Address5, Appellant_Postcode)
 
                 WHEN dv_appellantIsInUk = false
@@ -747,7 +751,7 @@ class paymentPendingDetainedDQRules(DQRulesBase):
                             THEN countryGovUkOocAdminJ IS NULL
 
                         WHEN dv_appellantIsInUk = false
-                            THEN countryGovUkOocAdminJ IN ('AF', 'AX', 'AL', 'DZ', 'AD', 'AO', 'AI', 'AG', 'AR', 'AM', 'AW', 'AC', 'AU', 'AT', 'AZ', 'BS', 'BH', 'BD', 'BB', 'BY', 'BE', 'BZ', 'BJ', 'BM', 'BT', 'BO', 'BQ', 'BA', 'BW', 'BR', 'IO', 'VG', 'BN', 'BG', 'BF', 'BI', 'KH', 'CM', 'CA', 'IC', 'CV', 'KY', 'CF', 'EA', 'TD', 'CL', 'CN', 'CX', 'CO', 'KM', 'CD', 'CG', 'CK', 'CR', 'HR', 'CU', 'CW', 'CY', 'CZ', 'DK', 'DJ', 'DM', 'DO', 'EC', 'EG', 'SV', 'GQ', 'ER', 'EE', 'ET', 'FK', 'FO', 'FJ', 'FI', 'FR', 'GF', 'PF', 'TF', 'GA', 'GM', 'GE', 'DE', 'GH', 'GI', 'GR', 'GL', 'GD', 'GP', 'GT', 'GN', 'GW', 'GY', 'HT', 'HN', 'HK', 'HU', 'IS', 'IN', 'ID', 'IR', 'IQ', 'IE', 'IL', 'IT', 'CI', 'JM', 'JP', 'JO', 'KZ', 'KE', 'KI', 'KO', 'KW', 'KG', 'LA', 'LV', 'LB', 'LS', 'LR', 'LY', 'LI', 'LT', 'LU', 'MO', 'MK', 'MG', 'YT', 'MW', 'MY', 'MV', 'ML', 'MT', 'MQ', 'MR', 'MU', 'MX', 'MD', 'MN', 'ME', 'MS', 'MA', 'MZ', 'MM', 'NA', 'NR', 'NF', 'NP', 'NL', 'NC', 'NZ', 'NI', 'NE', 'NG', 'NU', 'KP', 'NO', 'OM', 'PK', 'PW', 'PA', 'PG', 'PY', 'PE', 'PH', 'PN', 'PL', 'PT', 'PR', 'QA', 'RE', 'RO', 'RU', 'RW', 'SM', 'ST', 'SA', 'SN', 'RS', 'SC', 'SL', 'SG', 'SK', 'SI', 'SB', 'ZA', 'KR', 'SS', 'ES', 'LK', 'BQ', 'SH', 'KN', 'LC', 'MF', 'VC', 'SD', 'SR', 'SZ', 'SE', 'CH', 'SY', 'TW', 'TJ', 'TZ', 'TH', 'TL', 'TG', 'TK', 'TO', 'TT', 'TN', 'TR', 'TM', 'TC', 'TV', 'UG', 'UA', 'AE', 'GB', 'UY', 'US', 'UZ', 'VU', 'VA', 'VE', 'VN', 'WF', 'EH', 'WS', 'YE', 'ZM', 'ZW', 'PS', 'SO', 'MH', 'MC', 'FM', 'BC', 'ZZ')
+                            THEN countryGovUkOocAdminJ IS NOT NULL AND countryGovUkOocAdminJ IN ('AF', 'AX', 'AL', 'DZ', 'AD', 'AO', 'AI', 'AG', 'AR', 'AM', 'AW', 'AC', 'AU', 'AT', 'AZ', 'BS', 'BH', 'BD', 'BB', 'BY', 'BE', 'BZ', 'BJ', 'BM', 'BT', 'BO', 'BQ', 'BA', 'BW', 'BR', 'IO', 'VG', 'BN', 'BG', 'BF', 'BI', 'KH', 'CM', 'CA', 'IC', 'CV', 'KY', 'CF', 'EA', 'TD', 'CL', 'CN', 'CX', 'CO', 'KM', 'CD', 'CG', 'CK', 'CR', 'HR', 'CU', 'CW', 'CY', 'CZ', 'DK', 'DJ', 'DM', 'DO', 'EC', 'EG', 'SV', 'GQ', 'ER', 'EE', 'ET', 'FK', 'FO', 'FJ', 'FI', 'FR', 'GF', 'PF', 'TF', 'GA', 'GM', 'GE', 'DE', 'GH', 'GI', 'GR', 'GL', 'GD', 'GP', 'GT', 'GN', 'GW', 'GY', 'HT', 'HN', 'HK', 'HU', 'IS', 'IN', 'ID', 'IR', 'IQ', 'IE', 'IL', 'IT', 'CI', 'JM', 'JP', 'JO', 'KZ', 'KE', 'KI', 'KO', 'KW', 'KG', 'LA', 'LV', 'LB', 'LS', 'LR', 'LY', 'LI', 'LT', 'LU', 'MO', 'MK', 'MG', 'YT', 'MW', 'MY', 'MV', 'ML', 'MT', 'MQ', 'MR', 'MU', 'MX', 'MD', 'MN', 'ME', 'MS', 'MA', 'MZ', 'MM', 'NA', 'NR', 'NF', 'NP', 'NL', 'NC', 'NZ', 'NI', 'NE', 'NG', 'NU', 'KP', 'NO', 'OM', 'PK', 'PW', 'PA', 'PG', 'PY', 'PE', 'PH', 'PN', 'PL', 'PT', 'PR', 'QA', 'RE', 'RO', 'RU', 'RW', 'SM', 'ST', 'SA', 'SN', 'RS', 'SC', 'SL', 'SG', 'SK', 'SI', 'SB', 'ZA', 'KR', 'SS', 'ES', 'LK', 'BQ', 'SH', 'KN', 'LC', 'MF', 'VC', 'SD', 'SR', 'SZ', 'SE', 'CH', 'SY', 'TW', 'TJ', 'TZ', 'TH', 'TL', 'TG', 'TK', 'TO', 'TT', 'TN', 'TR', 'TM', 'TC', 'TV', 'UG', 'UA', 'AE', 'GB', 'UY', 'US', 'UZ', 'VU', 'VA', 'VE', 'VN', 'WF', 'EH', 'WS', 'YE', 'ZM', 'ZW', 'PS', 'SO', 'MH', 'MC', 'FM', 'BC', 'ZZ')
                         ELSE countryGovUkOocAdminJ IS NULL
                     END
             )"""
@@ -761,7 +765,7 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_homeOfficeDecisionDate_format"] = (
             """(
                 (
-                    (Detained IN (1,2,4) OR dv_appellantIsInUk)
+                    ((Detained IS NOT NULL AND Detained IN (1,2,4)) OR dv_appellantIsInUk <=> true)
                     AND homeOfficeDecisionDate IS NOT NULL
                     AND homeOfficeDecisionDate RLIKE r'^\\d{4}-\\d{2}-\\d{2}$'
                 )
@@ -773,8 +777,8 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_decisionLetterReceivedDate_format"] = (
             """(
                 (
-                    NOT dv_appellantIsInUk
-                    AND Detained NOT IN (1,2,4)
+                    dv_appellantIsInUk <=> false
+                    AND (Detained IS NULL OR Detained NOT IN (1,2,4))
                     AND decisionLetterReceivedDate IS NOT NULL
                     AND decisionLetterReceivedDate RLIKE r'^\\d{4}-\\d{2}-\\d{2}$'
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') NOT LIKE '%GWF%'
@@ -787,8 +791,8 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_dateEntryClearanceDecision_format"] = (
             """(
                 (
-                    NOT dv_appellantIsInUk
-                    AND Detained NOT IN (1,2,4)
+                    dv_appellantIsInUk <=> false
+                    AND (Detained IS NULL OR Detained NOT IN (1,2,4))
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
                     AND dateEntryClearanceDecision IS NOT NULL
                     AND dateEntryClearanceDecision RLIKE r'^\\d{4}-\\d{2}-\\d{2}$'
@@ -802,19 +806,19 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_homeOfficeReferenceNumber_not_null"] = (
             """(
                 (
-                    (Detained IN (1,2,4) OR dv_appellantIsInUk
+                    ((Detained IS NOT NULL AND Detained IN (1,2,4)) OR dv_appellantIsInUk <=> true
                      OR COALESCE(lu_HORef, HORef, FCONumber, '') NOT LIKE '%GWF%')
                     AND homeOfficeReferenceNumber IS NOT NULL
                 )
                 OR
                 (
-                    NOT dv_appellantIsInUk
-                    AND Detained NOT IN (1,2,4)
+                    dv_appellantIsInUk <=> false
+                    AND (Detained IS NULL OR Detained NOT IN (1,2,4))
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
                     AND (
                         (gwfReferenceNumber IS NOT NULL AND homeOfficeReferenceNumber IS NULL)
                         OR
-                        (gwfReferenceNumber IS NULL AND homeOfficeReferenceNumber = '999999999')
+                        (gwfReferenceNumber IS NULL AND homeOfficeReferenceNumber <=> '999999999')
                     )
                 )
             )"""
@@ -824,16 +828,16 @@ class paymentPendingDetainedDQRules(DQRulesBase):
         checks["valid_gwfReferenceNumber_not_null"] = (
             """(
                 (
-                    NOT dv_appellantIsInUk
-                    AND Detained NOT IN (1,2,4)
+                    dv_appellantIsInUk <=> false
+                    AND (Detained IS NULL OR Detained NOT IN (1,2,4))
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
                     AND COALESCE(lu_HORef, HORef, FCONumber) IS NOT NULL
                     AND gwfReferenceNumber IS NOT NULL
                 )
                 OR
                 (
-                    dv_appellantIsInUk
-                    OR Detained IN (1,2,4)
+                    dv_appellantIsInUk <=> true
+                    OR (Detained IS NOT NULL AND Detained IN (1,2,4))
                     OR COALESCE(lu_HORef, HORef, FCONumber, '') NOT LIKE '%GWF%'
                     OR COALESCE(lu_HORef, HORef, FCONumber) IS NULL
                 )

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpendingDetained_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpendingDetained_dq_rules.py
@@ -833,6 +833,7 @@ class paymentPendingDetainedDQRules(DQRulesBase):
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
                     AND COALESCE(lu_HORef, HORef, FCONumber) IS NOT NULL
                     AND gwfReferenceNumber IS NOT NULL
+                    AND gwfReferenceNumber LIKE 'GWF%'
                 )
                 OR
                 (

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
@@ -751,6 +751,7 @@ class paymentPendingDQRules(DQRulesBase):
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
                     AND COALESCE(lu_HORef, HORef, FCONumber) IS NOT NULL
                     AND gwfReferenceNumber IS NOT NULL
+                    AND gwfReferenceNumber LIKE 'GWF%'
                 )
                 OR
                 (

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/paymentpending_dq_rules.py
@@ -29,7 +29,7 @@ class paymentPendingDQRules(DQRulesBase):
             (
                 caseManagementCategory.value.code IS NULL OR
                 ARRAY_CONTAINS(
-                    TRANSFORM(caseManagementCategory.list_items, x -> x.code),
+                    COALESCE(TRANSFORM(caseManagementCategory.list_items, x -> x.code), ARRAY()),
                     caseManagementCategory.value.code
                 )
             )
@@ -39,7 +39,7 @@ class paymentPendingDQRules(DQRulesBase):
             (
                 caseManagementCategory.value.label IS NULL OR
                 ARRAY_CONTAINS(
-                    TRANSFORM(caseManagementCategory.list_items, x -> x.label),
+                    COALESCE(TRANSFORM(caseManagementCategory.list_items, x -> x.label), ARRAY()),
                     caseManagementCategory.value.label
                 )
             )
@@ -69,47 +69,47 @@ class paymentPendingDQRules(DQRulesBase):
             (
                 (
                     recordedOutOfTimeDecision IS NULL
-                    AND (OutOfTimeIssue IS NULL OR OutOfTimeIssue = False)
+                    AND (OutOfTimeIssue IS NULL OR OutOfTimeIssue <=> False)
                 )
                 OR
                 (
-                    recordedOutOfTimeDecision = 'Yes'
-                    AND OutOfTimeIssue = True
+                    recordedOutOfTimeDecision <=> 'Yes'
+                    AND OutOfTimeIssue <=> True
                     AND (
                         (
-                            ariaDesiredState IN ('paymentPending', 'appealSubmitted')
+                            ariaDesiredState IS NOT NULL AND ariaDesiredState IN ('paymentPending', 'appealSubmitted')
                             AND Outcome IS NOT NULL
-                            AND Outcome != 0
+                            AND NOT (Outcome <=> 0)
                         )
                         OR
                         (
-                            ariaDesiredState NOT IN ('paymentPending', 'appealSubmitted')
+                            ariaDesiredState IS NULL OR ariaDesiredState NOT IN ('paymentPending', 'appealSubmitted')
                         )
                     )
                 )
                 OR
                 (
-                    recordedOutOfTimeDecision = 'No'
-                    AND OutOfTimeIssue = True
-                    AND ariaDesiredState IN ('paymentPending', 'appealSubmitted')
-                    AND (Outcome IS NULL OR Outcome = 0)
+                    recordedOutOfTimeDecision <=> 'No'
+                    AND OutOfTimeIssue <=> True
+                    AND ariaDesiredState IS NOT NULL AND ariaDesiredState IN ('paymentPending', 'appealSubmitted')
+                    AND (Outcome IS NULL OR Outcome <=> 0)
                 )
             )
         """)
- 
+
 
         checks["valid_applicationOutOfTimeExplanation_valid_or_null"] = (
             "(applicationOutOfTimeExplanation IS NULL OR applicationOutOfTimeExplanation = 'This is a migrated ARIA case. Please refer to the documents.')"
         )
 
         checks["valid_outOfTimeDecisionType"] = (
-            """    (OutOfTimeIssue = True AND Outcome_no_filter != 0 AND outOfTimeDecisionType = 'approved') 
-                OR (outOfTimeDecisionType IS NULL)     
+            """    (OutOfTimeIssue <=> True AND NOT (Outcome_no_filter <=> 0) AND outOfTimeDecisionType <=> 'approved')
+                OR (outOfTimeDecisionType IS NULL)
             """
         )
 
         checks["valid_outOfTimeDecisionMaker"] = (
-            """    (OutOfTimeIssue = True AND Outcome_no_filter != 0 AND outOfTimeDecisionMaker = 'Tribunal Caseworker') 
+            """    (OutOfTimeIssue <=> True AND NOT (Outcome_no_filter <=> 0) AND outOfTimeDecisionMaker <=> 'Tribunal Caseworker')
                 OR (outOfTimeDecisionMaker IS NULL)
             """
         )
@@ -119,11 +119,11 @@ class paymentPendingDQRules(DQRulesBase):
         # # Null Values as accepted values as where Representation = AIP
         # ##############################
 
-        checks["valid_legalRepGivenName_not_null"] = "((dv_representation = 'LR' AND legalRepGivenName IS NOT NULL) OR (dv_representation != 'LR' AND legalRepGivenName IS NULL))"
+        checks["valid_legalRepGivenName_not_null"] = "((dv_representation <=> 'LR' AND legalRepGivenName IS NOT NULL) OR (NOT(dv_representation <=> 'LR') AND legalRepGivenName IS NULL))"
 
-        checks["valid_legalRepFamilyNamePaperJ_not_null"] = "((dv_representation = 'LR' AND legalRepFamilyNamePaperJ IS NOT NULL) OR (dv_representation != 'LR' AND legalRepFamilyNamePaperJ IS NULL))"
+        checks["valid_legalRepFamilyNamePaperJ_not_null"] = "((dv_representation <=> 'LR' AND legalRepFamilyNamePaperJ IS NOT NULL) OR (NOT(dv_representation <=> 'LR') AND legalRepFamilyNamePaperJ IS NULL))"
 
-        checks["valid_legalRepCompanyPaperJ_not_null"] = "((dv_representation = 'LR' AND legalRepCompanyPaperJ IS NOT NULL) OR (dv_representation != 'LR' AND legalRepCompanyPaperJ IS NULL))"
+        checks["valid_legalRepCompanyPaperJ_not_null"] = "((dv_representation <=> 'LR' AND legalRepCompanyPaperJ IS NOT NULL) OR (NOT(dv_representation <=> 'LR') AND legalRepCompanyPaperJ IS NULL))"
 
 
         # ##############################
@@ -143,7 +143,7 @@ class paymentPendingDQRules(DQRulesBase):
         # # ARIADM-771 (AppealType - legalRepDetails)
         # ##############################
 
-        checks["valid_legalrepEmail_not_null"] = "((dv_representation = 'LR' AND legalRepEmail IS NOT NULL AND legalRepEmail RLIKE r'^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$') OR (dv_representation != 'LR' AND legalRepEmail IS NULL))"
+        checks["valid_legalrepEmail_not_null"] = "((dv_representation <=> 'LR' AND legalRepEmail IS NOT NULL AND legalRepEmail RLIKE r'^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$') OR (NOT(dv_representation <=> 'LR') AND legalRepEmail IS NULL))"
 
         # ##############################
         # # ARIADM-758 (appellantDetails)
@@ -167,7 +167,7 @@ class paymentPendingDQRules(DQRulesBase):
         # ##############################
 
         checks["valid_legalRepHasAddress_yes_no"] = (
-            "((dv_representation = 'LR' AND legalRepHasAddress IS NOT NULL AND legalRepHasAddress IN ('Yes', 'No')) OR (dv_representation != 'LR' AND legalRepHasAddress IS NULL))"
+            "((dv_representation <=> 'LR' AND legalRepHasAddress IS NOT NULL AND legalRepHasAddress IN ('Yes', 'No')) OR (NOT(dv_representation <=> 'LR') AND legalRepHasAddress IS NULL))"
         )
 
         checks["valid_legalRepAddressUK"] = (
@@ -175,19 +175,19 @@ class paymentPendingDQRules(DQRulesBase):
                 (
                     dv_representation <=> 'LR'
                     AND legalRepHasAddress <=> 'Yes'
-                    AND RepresentativeId >= 0
+                    AND RepresentativeId IS NOT NULL AND RepresentativeId >= 0
                     AND legalRepAddressUK IS NOT NULL
                     AND legalRepAddressUK.AddressLine1 IS NOT NULL
                     AND legalRepAddressUK.PostTown IS NOT NULL
                 )
                 OR (
-                    dv_representation = 'LR'
+                    dv_representation <=> 'LR'
                     AND legalRepHasAddress <=> 'No'
-                    AND RepresentativeId >= 0
+                    AND RepresentativeId IS NOT NULL AND RepresentativeId >= 0
                     AND legalRepAddressUK IS NULL
                 )
                 OR (
-                    dv_representation != 'LR'
+                    NOT(dv_representation <=> 'LR')
                     AND legalRepAddressUK IS NULL
                 )
             )"""
@@ -195,47 +195,47 @@ class paymentPendingDQRules(DQRulesBase):
 
         checks["valid_oocAddressLine1"] = (
             """(
-                (dv_representation = 'LR' AND oocAddressLine1 IS NOT NULL AND legalRepHasAddress <=> 'No')
+                (dv_representation <=> 'LR' AND oocAddressLine1 IS NOT NULL AND legalRepHasAddress <=> 'No')
                 OR
-                (dv_representation = 'LR' AND oocAddressLine1 IS NULL AND legalRepHasAddress <=> 'Yes')
+                (dv_representation <=> 'LR' AND oocAddressLine1 IS NULL AND legalRepHasAddress <=> 'Yes')
                 OR
-                (dv_representation != 'LR' AND oocAddressLine1 IS NULL)
+                (NOT(dv_representation <=> 'LR') AND oocAddressLine1 IS NULL)
             )"""
         )
         checks["valid_oocAddressLine2"] = (
             """(
-                (dv_representation = 'LR' AND oocAddressLine2 IS NOT NULL AND legalRepHasAddress <=> 'No')
+                (dv_representation <=> 'LR' AND oocAddressLine2 IS NOT NULL AND legalRepHasAddress <=> 'No')
                 OR
-                (dv_representation = 'LR' AND oocAddressLine2 IS NULL AND legalRepHasAddress <=> 'Yes')
+                (dv_representation <=> 'LR' AND oocAddressLine2 IS NULL AND legalRepHasAddress <=> 'Yes')
                 OR
-                (dv_representation != 'LR' AND oocAddressLine2 IS NULL)
+                (NOT(dv_representation <=> 'LR') AND oocAddressLine2 IS NULL)
             )"""
         )
         checks["valid_oocAddressLine3"] = (
             """(
-                (dv_representation = 'LR' AND legalRepHasAddress <=> 'No')
+                (dv_representation <=> 'LR' AND legalRepHasAddress <=> 'No')
                 OR
-                (dv_representation = 'LR' AND legalRepHasAddress <=> 'Yes')
+                (dv_representation <=> 'LR' AND legalRepHasAddress <=> 'Yes')
                 OR
-                (dv_representation != 'LR' AND oocAddressLine3 IS NULL)
+                (NOT(dv_representation <=> 'LR') AND oocAddressLine3 IS NULL)
             )"""
         )
         checks["valid_oocAddressLine4"] = (
             """(
-                (dv_representation = 'LR' AND legalRepHasAddress <=> 'No')
+                (dv_representation <=> 'LR' AND legalRepHasAddress <=> 'No')
                 OR
-                (dv_representation = 'LR' AND legalRepHasAddress <=> 'Yes')
+                (dv_representation <=> 'LR' AND legalRepHasAddress <=> 'Yes')
                 OR
-                (dv_representation != 'LR' AND oocAddressLine4 IS NULL)
+                (NOT(dv_representation <=> 'LR') AND oocAddressLine4 IS NULL)
             )"""
         )
         checks["valid_oocrCountryGovUkAdminJ"] = (
             """(
-                (dv_representation = 'LR' AND legalRepHasAddress <=> 'No' AND oocLrCountryGovUkAdminJ IS NOT NULL)
+                (dv_representation <=> 'LR' AND legalRepHasAddress <=> 'No' AND oocLrCountryGovUkAdminJ IS NOT NULL)
                 OR
-                (dv_representation = 'LR' AND legalRepHasAddress <=> 'Yes' AND oocLrCountryGovUkAdminJ IS NULL)
+                (dv_representation <=> 'LR' AND legalRepHasAddress <=> 'Yes' AND oocLrCountryGovUkAdminJ IS NULL)
                 OR
-                (dv_representation != 'LR' AND CaseRep_Address5 IS NULL)
+                (NOT(dv_representation <=> 'LR') AND CaseRep_Address5 IS NULL)
             )"""
         )
 
@@ -248,7 +248,7 @@ class paymentPendingDQRules(DQRulesBase):
             """(
                 (appellantNationalities IS NOT NULL)
                 AND
-                EXISTS(appellantNationalities, x -> x.value.code IN ('AF', 'AX', 'AL', 'DZ', 'AS', 'AD', 'AO', 'AI', 'AQ', 'AG', 'AR', 'AM', 'AW', 'AU', 'AT', 'AZ', 'BS', 'BH', 'BD', 'BB', 'BY', 'BE', 'BZ', 'BJ', 'BM', 'BT', 'BO', 'BQ', 'BA', 'BW', 'BV', 'BR', 'BC', 'VG', 'IO', 'BN', 'BG', 'BF', 'BI', 'KH', 'CM', 'CA', 'CV', 'KY', 'CF', 'TD', 'CL', 'CN', 'HK', 'MO', 'CX', 'CC', 'CO', 'KM', 'CG', 'CD', 'CK', 'CR', 'CI', 'HR', 'CU', 'CW', 'CY', 'CZ', 'DK', 'DJ', 'DM', 'DO', 'EC', 'EG', 'SV', 'GQ', 'ER', 'EE', 'ET', 'FK', 'FO', 'FJ', 'FI', 'FR', 'GF', 'PF', 'TF', 'GA', 'GM', 'GE', 'DE', 'GH', 'GI', 'GR', 'GL', 'GD', 'GP', 'GU', 'GT', 'GG', 'GN', 'GW', 'GY', 'HT', 'HM', 'VA', 'HN', 'HU', 'IS', 'IN', 'ID', 'IR', 'IQ', 'IE', 'IM', 'IL', 'IT', 'JM', 'JP', 'JE', 'JO', 'KZ', 'KE', 'KI', 'KP', 'KR', 'KO', 'KW', 'KG', 'LA', 'LV', 'LB', 'LS', 'LR', 'LY', 'LI', 'LT', 'LU', 'MK', 'MG', 'MW', 'MY', 'MV', 'ML', 'MT', 'MH', 'MQ', 'MR', 'MU', 'YT', 'MX', 'FM', 'MD', 'MC', 'MN', 'ME', 'MS', 'MA', 'MZ', 'MM', 'NA', 'NR', 'NP', 'NL', 'AN', 'NC', 'NZ', 'NI', 'NE', 'NG', 'NU', 'NF', 'MP', 'NO', 'OM', 'PK', 'PW', 'PS', 'PA', 'PG', 'PY', 'PE', 'PH', 'PN', 'PL', 'PT', 'PR', 'QA', 'RE', 'RO', 'RU', 'RW', 'BL', 'SH', 'KN', 'LC', 'MF', 'PM', 'VC', 'WS', 'SM', 'ST', 'SA', 'SN', 'RS', 'SC', 'SL', 'SG', 'SX', 'SK', 'SI', 'SB', 'SO', 'ZA', 'GS', 'SS', 'ES', 'LK', 'ZZ', 'SD', 'SR', 'SJ', 'SZ', 'SE', 'CH', 'SY', 'TW', 'TJ', 'TZ', 'TH', 'TL', 'TG', 'TK', 'TO', 'TT', 'TN', 'TR', 'TM', 'TC', 'TV', 'UG', 'UA', 'AE', 'GB', 'US', 'UM', 'UY', 'UZ', 'VU', 'VE', 'VN', 'VI', 'WF', 'EH', 'YE', 'ZM', 'ZW'))
+                EXISTS(appellantNationalities, x -> x.value.code IS NOT NULL AND x.value.code IN ('AF', 'AX', 'AL', 'DZ', 'AS', 'AD', 'AO', 'AI', 'AQ', 'AG', 'AR', 'AM', 'AW', 'AU', 'AT', 'AZ', 'BS', 'BH', 'BD', 'BB', 'BY', 'BE', 'BZ', 'BJ', 'BM', 'BT', 'BO', 'BQ', 'BA', 'BW', 'BV', 'BR', 'BC', 'VG', 'IO', 'BN', 'BG', 'BF', 'BI', 'KH', 'CM', 'CA', 'CV', 'KY', 'CF', 'TD', 'CL', 'CN', 'HK', 'MO', 'CX', 'CC', 'CO', 'KM', 'CG', 'CD', 'CK', 'CR', 'CI', 'HR', 'CU', 'CW', 'CY', 'CZ', 'DK', 'DJ', 'DM', 'DO', 'EC', 'EG', 'SV', 'GQ', 'ER', 'EE', 'ET', 'FK', 'FO', 'FJ', 'FI', 'FR', 'GF', 'PF', 'TF', 'GA', 'GM', 'GE', 'DE', 'GH', 'GI', 'GR', 'GL', 'GD', 'GP', 'GU', 'GT', 'GG', 'GN', 'GW', 'GY', 'HT', 'HM', 'VA', 'HN', 'HU', 'IS', 'IN', 'ID', 'IR', 'IQ', 'IE', 'IM', 'IL', 'IT', 'JM', 'JP', 'JE', 'JO', 'KZ', 'KE', 'KI', 'KP', 'KR', 'KO', 'KW', 'KG', 'LA', 'LV', 'LB', 'LS', 'LR', 'LY', 'LI', 'LT', 'LU', 'MK', 'MG', 'MW', 'MY', 'MV', 'ML', 'MT', 'MH', 'MQ', 'MR', 'MU', 'YT', 'MX', 'FM', 'MD', 'MC', 'MN', 'ME', 'MS', 'MA', 'MZ', 'MM', 'NA', 'NR', 'NP', 'NL', 'AN', 'NC', 'NZ', 'NI', 'NE', 'NG', 'NU', 'NF', 'MP', 'NO', 'OM', 'PK', 'PW', 'PS', 'PA', 'PG', 'PY', 'PE', 'PH', 'PN', 'PL', 'PT', 'PR', 'QA', 'RE', 'RO', 'RU', 'RW', 'BL', 'SH', 'KN', 'LC', 'MF', 'PM', 'VC', 'WS', 'SM', 'ST', 'SA', 'SN', 'RS', 'SC', 'SL', 'SG', 'SX', 'SK', 'SI', 'SB', 'SO', 'ZA', 'GS', 'SS', 'ES', 'LK', 'ZZ', 'SD', 'SR', 'SJ', 'SZ', 'SE', 'CH', 'SY', 'TW', 'TJ', 'TZ', 'TH', 'TL', 'TG', 'TK', 'TO', 'TT', 'TN', 'TR', 'TM', 'TC', 'TV', 'UG', 'UA', 'AE', 'GB', 'US', 'UM', 'UY', 'UZ', 'VU', 'VE', 'VN', 'VI', 'WF', 'EH', 'YE', 'ZM', 'ZW'))
             )"""
         )
 
@@ -260,7 +260,7 @@ class paymentPendingDQRules(DQRulesBase):
             )"""
         )
 
-        checks["valid_isAriaMigratedFeeExemption_yes_no"] = "((CasePrefix = 'DA' AND isAriaMigratedFeeExemption <=> 'Yes') OR (CasePrefix != 'DA' AND isAriaMigratedFeeExemption <=> 'No'))"
+        checks["valid_isAriaMigratedFeeExemption_yes_no"] = "((CasePrefix <=> 'DA' AND isAriaMigratedFeeExemption <=> 'Yes') OR (NOT(CasePrefix <=> 'DA') AND isAriaMigratedFeeExemption <=> 'No'))"
 
         # ##############################
         # # ARIADM-712 (flagsLabel)- caseFlags
@@ -268,7 +268,7 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_caseFlags_name_in_list"] = """(
             (
                 (
-                    EXISTS(valid_categoryIdList, x -> x IN (7, 25))
+                    EXISTS(COALESCE(valid_categoryIdList, ARRAY()), x -> x IN (7, 25))
                 )
                 AND
                 EXISTS(caseFlags.details, x -> x.value.flagComment IS NULL)
@@ -278,7 +278,7 @@ class paymentPendingDQRules(DQRulesBase):
             OR
             (
                 (
-                    NOT EXISTS(valid_categoryIdList, x -> x IN (7, 25))
+                    NOT EXISTS(COALESCE(valid_categoryIdList, ARRAY()), x -> x IN (7, 25))
                 )
                 AND
                 ARRAY_CONTAINS(TRANSFORM(caseFlags.details, x -> x.value.name), caseFlags.details[0].value.name)
@@ -287,7 +287,7 @@ class paymentPendingDQRules(DQRulesBase):
 
         # checks["valid_caseFlags_name_in_list"] = """
         # (
-        #   (array_contains(valid_categoryIdList, (7, 25)) OR caseFlags.details IS NULL OR
+        #   (array_contains(COALESCE(valid_categoryIdList, ARRAY()), (7, 25)) OR caseFlags.details IS NULL OR
         #   ARRAY_CONTAINS(
         #     TRANSFORM(caseFlags.details, x -> x.value.name),
         #     caseFlags.details[0].value.name
@@ -297,6 +297,7 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_caseFlags_pathId_in_list"] = """
         (
             caseFlags.details IS NULL OR
+            caseFlags.details[0].value.path[0].id IS NULL OR
             ARRAY_CONTAINS(
                 TRANSFORM(caseFlags.details, x -> x.value.path[0].id),
                 caseFlags.details[0].value.path[0].id
@@ -306,6 +307,7 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_caseFlags_flagCode_in_list"] = """
         (
             caseFlags.details IS NULL OR
+            caseFlags.details[0].value.flagCode IS NULL OR
             ARRAY_CONTAINS(
                 TRANSFORM(caseFlags.details, x -> x.value.flagCode),
                 caseFlags.details[0].value.flagCode
@@ -325,13 +327,13 @@ class paymentPendingDQRules(DQRulesBase):
                     OR
                     (
                         NOT (
-                            array_contains(valid_categoryIdList, 7) OR
-                            array_contains(valid_categoryIdList, 8) OR
-                            array_contains(valid_categoryIdList, 24) OR
-                            array_contains(valid_categoryIdList, 25) OR
-                            array_contains(valid_categoryIdList, 31) OR
-                            array_contains(valid_categoryIdList, 32) OR
-                            array_contains(valid_categoryIdList, 41)
+                            array_contains(COALESCE(valid_categoryIdList, ARRAY()), 7) OR
+                            array_contains(COALESCE(valid_categoryIdList, ARRAY()), 8) OR
+                            array_contains(COALESCE(valid_categoryIdList, ARRAY()), 24) OR
+                            array_contains(COALESCE(valid_categoryIdList, ARRAY()), 25) OR
+                            array_contains(COALESCE(valid_categoryIdList, ARRAY()), 31) OR
+                            array_contains(COALESCE(valid_categoryIdList, ARRAY()), 32) OR
+                            array_contains(COALESCE(valid_categoryIdList, ARRAY()), 41)
                         )
                     )
                 )
@@ -341,13 +343,13 @@ class paymentPendingDQRules(DQRulesBase):
             (
                 (
                     (
-                        array_contains(valid_categoryIdList, 7) OR
-                        array_contains(valid_categoryIdList, 8) OR
-                        array_contains(valid_categoryIdList, 24) OR
-                        array_contains(valid_categoryIdList, 25) OR
-                        array_contains(valid_categoryIdList, 31) OR
-                        array_contains(valid_categoryIdList, 32) OR
-                        array_contains(valid_categoryIdList, 41)
+                        array_contains(COALESCE(valid_categoryIdList, ARRAY()), 7) OR
+                        array_contains(COALESCE(valid_categoryIdList, ARRAY()), 8) OR
+                        array_contains(COALESCE(valid_categoryIdList, ARRAY()), 24) OR
+                        array_contains(COALESCE(valid_categoryIdList, ARRAY()), 25) OR
+                        array_contains(COALESCE(valid_categoryIdList, ARRAY()), 31) OR
+                        array_contains(COALESCE(valid_categoryIdList, ARRAY()), 32) OR
+                        array_contains(COALESCE(valid_categoryIdList, ARRAY()), 41)
                     )
                     OR
                     (HOANRef IS NOT NULL)
@@ -356,7 +358,7 @@ class paymentPendingDQRules(DQRulesBase):
                 AND
                 (
                     (
-                        (array_contains(valid_categoryIdList, 7) OR array_contains(valid_categoryIdList, 25))
+                        (array_contains(COALESCE(valid_categoryIdList, ARRAY()), 7) OR array_contains(COALESCE(valid_categoryIdList, ARRAY()), 25))
                         AND EXISTS(
                             TRANSFORM(caseFlags.details, x -> x.value.flagComment),
                             x -> x IS NULL
@@ -364,7 +366,7 @@ class paymentPendingDQRules(DQRulesBase):
                     )
                     OR
                     (
-                        (array_contains(valid_categoryIdList, 8) OR array_contains(valid_categoryIdList, 24) OR array_contains(valid_categoryIdList, 31) OR array_contains(valid_categoryIdList, 32) OR array_contains(valid_categoryIdList, 41))
+                        (array_contains(COALESCE(valid_categoryIdList, ARRAY()), 8) OR array_contains(COALESCE(valid_categoryIdList, ARRAY()), 24) OR array_contains(COALESCE(valid_categoryIdList, ARRAY()), 31) OR array_contains(COALESCE(valid_categoryIdList, ARRAY()), 32) OR array_contains(COALESCE(valid_categoryIdList, ARRAY()), 41))
                         AND NOT EXISTS(
                             TRANSFORM(caseFlags.details, x -> x.value.flagComment),
                             x -> x IS NULL
@@ -384,6 +386,7 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_caseFlags_hearingRelevant_in_list"] = """
         (
             caseFlags.details IS NULL OR
+            caseFlags.details[0].value.hearingRelevant IS NULL OR
             ARRAY_CONTAINS(
                 TRANSFORM(caseFlags.details, x -> x.value.hearingRelevant),
                 caseFlags.details[0].value.hearingRelevant
@@ -692,13 +695,13 @@ class paymentPendingDQRules(DQRulesBase):
         # ARIADM-788 and ARIADM-792 (homeOffice)
         #########################################
         checks["valid_homeOfficeDecisionDate_format"] = (
-            "((dv_appellantIsInUk AND homeOfficeDecisionDate IS NOT NULL AND homeOfficeDecisionDate RLIKE r'^\\d{4}-\\d{2}-\\d{2}$') OR (homeOfficeDecisionDate IS NULL))"
+            "((dv_appellantIsInUk <=> true AND homeOfficeDecisionDate IS NOT NULL AND homeOfficeDecisionDate RLIKE r'^\\d{4}-\\d{2}-\\d{2}$') OR (homeOfficeDecisionDate IS NULL))"
         )
 
         checks["valid_decisionLetterReceivedDate_format"] = (
             """(
                 (
-                    NOT dv_appellantIsInUk
+                    dv_appellantIsInUk <=> false
                     AND decisionLetterReceivedDate IS NOT NULL
                     AND decisionLetterReceivedDate RLIKE r'^\\d{4}-\\d{2}-\\d{2}$'
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') NOT LIKE '%GWF%'
@@ -710,7 +713,7 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_dateEntryClearanceDecision_format"] = (
             """(
                 (
-                    NOT dv_appellantIsInUk
+                    dv_appellantIsInUk <=> false
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
                     AND dateEntryClearanceDecision IS NOT NULL
                     AND dateEntryClearanceDecision RLIKE r'^\\d{4}-\\d{2}-\\d{2}$'
@@ -724,13 +727,13 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_homeOfficeReferenceNumber_not_null"] = (
             """(
                 (
-                    (dv_appellantIsInUk
+                    (dv_appellantIsInUk <=> true
                      OR COALESCE(lu_HORef, HORef, FCONumber, '') NOT LIKE '%GWF%')
                     AND homeOfficeReferenceNumber IS NOT NULL
                 )
                 OR
                 (
-                    NOT dv_appellantIsInUk
+                    dv_appellantIsInUk <=> false
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
                     AND (
                         (gwfReferenceNumber IS NOT NULL AND homeOfficeReferenceNumber IS NULL)
@@ -744,14 +747,14 @@ class paymentPendingDQRules(DQRulesBase):
         checks["valid_gwfReferenceNumber_not_null"] = (
             """(
                 (
-                    NOT dv_appellantIsInUk
+                    dv_appellantIsInUk <=> false
                     AND COALESCE(lu_HORef, HORef, FCONumber, '') LIKE '%GWF%'
                     AND COALESCE(lu_HORef, HORef, FCONumber) IS NOT NULL
                     AND gwfReferenceNumber IS NOT NULL
                 )
                 OR
                 (
-                    dv_appellantIsInUk
+                    dv_appellantIsInUk <=> true
                     OR COALESCE(lu_HORef, HORef, FCONumber, '') NOT LIKE '%GWF%'
                     OR COALESCE(lu_HORef, HORef, FCONumber) IS NULL
                 )

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
@@ -295,17 +295,14 @@ class prepareForHearingDQRules(DQRulesBase):
             """
             (
                 (
-                    listCaseHearingDate <=>
+                    listCaseHearingDate IS NOT NULL
+                    AND listCaseHearingDate <=>
                         CONCAT(date_format(CAST(HearingDate AS timestamp), 'yyyy-MM-dd'),'T',
                             CASE
                             WHEN StartTime IS NULL THEN '00:00:00.000'
                             ELSE date_format(CAST(StartTime AS timestamp), 'HH:mm:ss.SSS')
                             END)
                         AND CaseStatus_dec IS NOT NULL AND CaseStatus_dec IN (37,38)
-                )
-                OR
-                (
-                    (CaseStatus_dec NOT IN (37,38) OR CaseStatus_dec IS NULL) AND listCaseHearingDate IS NULL
                 )
             )
             """)

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
@@ -11,102 +11,98 @@ class prepareForHearingDQRules(DQRulesBase):
         return checks
 
     def get_checks_hearing_response(self, checks={}):
-        checks["valid_isRemoteHearing"] = ("(isRemoteHearing = 'No')")
+        checks["valid_isRemoteHearing"] = ("(isRemoteHearing <=> 'No')")
 
         checks["valid_isAppealSuitableToFloat"] = (
             """(
-                CaseStatus_dec IN (37,38)
+                CaseStatus_dec IS NOT NULL AND CaseStatus_dec IN (37,38)
                 AND
                 (
-                    (listTypeId = 5 AND isAppealSuitableToFloat = 'Yes')
+                    (listTypeId <=> 5 AND isAppealSuitableToFloat <=> 'Yes')
                     OR
-                    ((listTypeId != 5 OR listTypeId IS NULL) AND isAppealSuitableToFloat = 'No')
+                    ((listTypeId != 5 OR listTypeId IS NULL) AND isAppealSuitableToFloat <=> 'No')
                 )
             )
             OR
             (
-                CaseStatus_dec NOT IN (37,38)
+                (CaseStatus_dec IS NULL OR CaseStatus_dec NOT IN (37,38))
                 AND isAppealSuitableToFloat IS NULL
-            )
-            OR
-            (
-                CaseStatus_dec IS NULL AND isAppealSuitableToFloat IS NULL
             )"""
         )
 
-        checks["valid_isMultimediaAllowed"] = ("(isMultimediaAllowed = 'Granted')")
+        checks["valid_isMultimediaAllowed"] = ("(isMultimediaAllowed <=> 'Granted')")
 
-        checks["valid_multimediaTribunalResponse"] = ("(multimediaTribunalResponse = 'This is a migrated ARIA case. Please refer to the documents.')")
+        checks["valid_multimediaTribunalResponse"] = ("(multimediaTribunalResponse <=> 'This is a migrated ARIA case. Please refer to the documents.')")
 
-        checks["valid_multimediaDecisionForDisplay"] = ("(multimediaDecisionForDisplay = 'Granted - This is a migrated ARIA case. Please refer to the documents.')")
+        checks["valid_multimediaDecisionForDisplay"] = ("(multimediaDecisionForDisplay <=> 'Granted - This is a migrated ARIA case. Please refer to the documents.')")
 
         checks["valid_isInCameraCourtAllowed"] = (
             """(
-                (InCamera = 1 AND isInCameraCourtAllowed = 'Granted')
+                (InCamera <=> 1 AND isInCameraCourtAllowed <=> 'Granted')
                 OR
-                (InCamera != 1 AND isInCameraCourtAllowed IS NULL)
+                (NOT(InCamera <=> 1) AND isInCameraCourtAllowed IS NULL)
             )"""
         )
 
         checks["valid_inCameraCourtTribunalResponse"] = (
             """(
-                (InCamera = 1 AND inCameraCourtTribunalResponse = 'This is a migrated ARIA case. Please refer to the documents.')
+                (InCamera <=> 1 AND inCameraCourtTribunalResponse <=> 'This is a migrated ARIA case. Please refer to the documents.')
                 OR
-                (InCamera != 1 AND inCameraCourtTribunalResponse IS NULL)
+                (NOT(InCamera <=> 1) AND inCameraCourtTribunalResponse IS NULL)
             )"""
         )
 
         checks["valid_inCameraCourtDecisionForDisplay"] = (
             """(
-                (InCamera = 1 AND inCameraCourtDecisionForDisplay = 'Granted - This is a migrated ARIA case. Please refer to the documents.')
+                (InCamera <=> 1 AND inCameraCourtDecisionForDisplay <=> 'Granted - This is a migrated ARIA case. Please refer to the documents.')
                 OR
-                (InCamera != 1 AND inCameraCourtDecisionForDisplay IS NULL)
+                (NOT(InCamera <=> 1) AND inCameraCourtDecisionForDisplay IS NULL)
             )"""
         )
 
         checks["valid_isSingleSexCourtAllowed"] = (
             """(
-                (CourtPreference IN (1, 2) AND isSingleSexCourtAllowed = 'Granted')
+                (CourtPreference IS NOT NULL AND CourtPreference IN (1, 2) AND isSingleSexCourtAllowed <=> 'Granted')
                 OR
-                (CourtPreference NOT IN (1, 2) AND isSingleSexCourtAllowed IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND isSingleSexCourtAllowed IS NULL)
             )"""
         )
 
         checks["valid_singleSexCourtTribunalResponse"] = (
             """(
-                (CourtPreference IN (1, 2) AND singleSexCourtTribunalResponse = 'This is a migrated ARIA case. Please refer to the documents.')
+                (CourtPreference IS NOT NULL AND CourtPreference IN (1, 2) AND singleSexCourtTribunalResponse <=> 'This is a migrated ARIA case. Please refer to the documents.')
                 OR
-                (CourtPreference NOT IN (1, 2)  AND singleSexCourtTribunalResponse IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND singleSexCourtTribunalResponse IS NULL)
             )"""
         )
 
         checks["valid_singleSexCourtDecisionForDisplay"] = (
             """(
-                (CourtPreference IN (1, 2)  AND singleSexCourtDecisionForDisplay = 'Granted - This is a migrated ARIA case. Please refer to the documents.')
+                (CourtPreference IS NOT NULL AND CourtPreference IN (1, 2) AND singleSexCourtDecisionForDisplay <=> 'Granted - This is a migrated ARIA case. Please refer to the documents.')
                 OR
-                (CourtPreference NOT IN (1, 2)  AND singleSexCourtDecisionForDisplay IS NULL)
+                ((CourtPreference IS NULL OR CourtPreference NOT IN (1, 2)) AND singleSexCourtDecisionForDisplay IS NULL)
             )"""
         )
 
-        checks["valid_isVulnerabilitiesAllowed"] = ("(isVulnerabilitiesAllowed = 'Granted')")
+        checks["valid_isVulnerabilitiesAllowed"] = ("(isVulnerabilitiesAllowed <=> 'Granted')")
 
-        checks["valid_vulnerabilitiesTribunalResponse"] = ("(vulnerabilitiesTribunalResponse = 'This is a migrated ARIA case. Please refer to the documents.')")
+        checks["valid_vulnerabilitiesTribunalResponse"] = ("(vulnerabilitiesTribunalResponse <=> 'This is a migrated ARIA case. Please refer to the documents.')")
 
-        checks["valid_vulnerabilitiesDecisionForDisplay"] = ("(vulnerabilitiesDecisionForDisplay = 'Granted - This is a migrated ARIA case. Please refer to the documents.')")
+        checks["valid_vulnerabilitiesDecisionForDisplay"] = ("(vulnerabilitiesDecisionForDisplay <=> 'Granted - This is a migrated ARIA case. Please refer to the documents.')")
 
-        checks["valid_isRemoteHearingAllowed"] = ("(isRemoteHearingAllowed = 'Granted')")
+        checks["valid_isRemoteHearingAllowed"] = ("(isRemoteHearingAllowed <=> 'Granted')")
 
-        checks["valid_remoteVideoCallTribunalResponse"] = ("(remoteVideoCallTribunalResponse = 'This is a migrated ARIA case. Please refer to the documents.')")
+        checks["valid_remoteVideoCallTribunalResponse"] = ("(remoteVideoCallTribunalResponse <=> 'This is a migrated ARIA case. Please refer to the documents.')")
 
-        checks["valid_remoteHearingDecisionForDisplay"] = ("(remoteHearingDecisionForDisplay = 'Granted - This is a migrated ARIA case. Please refer to the documents.')")
+        checks["valid_remoteHearingDecisionForDisplay"] = ("(remoteHearingDecisionForDisplay <=> 'Granted - This is a migrated ARIA case. Please refer to the documents.')")
 
-        checks["valid_isAdditionalAdjustmentsAllowed"] = ("(isAdditionalAdjustmentsAllowed = 'Granted')")
+        checks["valid_isAdditionalAdjustmentsAllowed"] = ("(isAdditionalAdjustmentsAllowed <=> 'Granted')")
 
-        checks["valid_additionalTribunalResponse"] = ("(additionalTribunalResponse = 'This is a migrated ARIA case. Please refer to the documents.')")
+        checks["valid_additionalTribunalResponse"] = ("(additionalTribunalResponse <=> 'This is a migrated ARIA case. Please refer to the documents.')")
 
-        checks["valid_otherDecisionForDisplay"] = ("(otherDecisionForDisplay = 'Granted - This is a migrated ARIA case. Please refer to the documents.')")
+        checks["valid_otherDecisionForDisplay"] = ("(otherDecisionForDisplay <=> 'Granted - This is a migrated ARIA case. Please refer to the documents.')")
 
-        checks["valid_isAdditionalInstructionAllowed"] = ("(isAdditionalInstructionAllowed = 'Yes')")
+        checks["valid_isAdditionalInstructionAllowed"] = ("(isAdditionalInstructionAllowed <=> 'Yes')")
 
         checks["valid_additionalInstructionsTribunalResponse"] = ("""
             additionalInstructionsTribunalResponse IS NULL OR
@@ -137,7 +133,7 @@ class prepareForHearingDQRules(DQRulesBase):
             listingLength IS NULL
             OR
             (
-                element_at(listingLength, 'hours') =
+                element_at(listingLength, 'hours') <=>
                     CASE
                         WHEN TimeEstimate IS NULL THEN 0
                         WHEN CAST(TimeEstimate AS INT) = 0 THEN 0
@@ -148,7 +144,7 @@ class prepareForHearingDQRules(DQRulesBase):
 
                 AND
 
-                element_at(listingLength, 'minutes') =
+                element_at(listingLength, 'minutes') <=>
                     CASE
                         WHEN TimeEstimate IS NULL THEN 30
                         WHEN CAST(TimeEstimate AS INT) = 0 THEN 30
@@ -170,18 +166,18 @@ class prepareForHearingDQRules(DQRulesBase):
         (
         -- Case: VisitVisaType = 1
         (
-            VisitVisaType = 1 AND
-            hearingChannel.value.code = 'ONPPRS' AND
-            hearingChannel.value.label = 'On The Papers'
+            VisitVisaType <=> 1 AND
+            hearingChannel.value.code <=> 'ONPPRS' AND
+            hearingChannel.value.label <=> 'On The Papers'
         )
         )
         OR
         (
         -- Case: VisitVisaType = 2
         (
-            VisitVisaType = 2 AND
-            hearingChannel.value.code = 'INTER' AND
-            hearingChannel.value.label = 'In Person'
+            VisitVisaType <=> 2 AND
+            hearingChannel.value.code <=> 'INTER' AND
+            hearingChannel.value.label <=> 'In Person'
         )
         )
         OR
@@ -196,7 +192,7 @@ class prepareForHearingDQRules(DQRulesBase):
         """)
 
         checks["valid_witnessDetails"] = (
-            "(size(witnessDetails) = 0)"
+            "(COALESCE(size(witnessDetails), 0) = 0)"
         )
 
         checks["valid_listingLocation"] = ("""
@@ -205,8 +201,8 @@ class prepareForHearingDQRules(DQRulesBase):
                 ListedCentre IS NULL
                 OR
                 (
-                    listingLocation.value.code = locationCode AND
-                    listingLocation.value.label = locationLabel
+                    listingLocation.value.code <=> locationCode AND
+                    listingLocation.value.label <=> locationLabel
                 )
             )
             OR
@@ -221,72 +217,72 @@ class prepareForHearingDQRules(DQRulesBase):
         """)
 
         checks["valid_witness1InterpreterSignLanguage"] = (
-            "(size(witness1InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness1InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness2InterpreterSignLanguage"] = (
-            "(size(witness2InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness2InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness3InterpreterSignLanguage"] = (
-            "(size(witness3InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness3InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness4InterpreterSignLanguage"] = (
-            "(size(witness4InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness4InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness5InterpreterSignLanguage"] = (
-            "(size(witness5InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness5InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness6InterpreterSignLanguage"] = (
-            "(size(witness6InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness6InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness7InterpreterSignLanguage"] = (
-            "(size(witness7InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness7InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness8InterpreterSignLanguage"] = (
-            "(size(witness8InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness8InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness9InterpreterSignLanguage"] = (
-            "(size(witness9InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness9InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness10InterpreterSignLanguage"] = (
-            "(size(witness10InterpreterSignLanguage) = 0)"
+            "(COALESCE(size(witness10InterpreterSignLanguage), 0) = 0)"
         )
         checks["valid_witness1InterpreterSpokenLanguage"] = (
-            "(size(witness1InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness1InterpreterSpokenLanguage), 0) = 0)"
         )
         checks["valid_witness2InterpreterSpokenLanguage"] = (
-            "(size(witness2InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness2InterpreterSpokenLanguage), 0) = 0)"
         )
         checks["valid_witness3InterpreterSpokenLanguage"] = (
-            "(size(witness3InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness3InterpreterSpokenLanguage), 0) = 0)"
         )
         checks["valid_witness4InterpreterSpokenLanguage"] = (
-            "(size(witness4InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness4InterpreterSpokenLanguage), 0) = 0)"
         )
         checks["valid_witness5InterpreterSpokenLanguage"] = (
-            "(size(witness5InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness5InterpreterSpokenLanguage), 0) = 0)"
         )
         checks["valid_witness6InterpreterSpokenLanguage"] = (
-            "(size(witness6InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness6InterpreterSpokenLanguage), 0) = 0)"
         )
         checks["valid_witness7InterpreterSpokenLanguage"] = (
-            "(size(witness7InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness7InterpreterSpokenLanguage), 0) = 0)"
         )
         checks["valid_witness8InterpreterSpokenLanguage"] = (
-            "(size(witness8InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness8InterpreterSpokenLanguage), 0) = 0)"
         )
         checks["valid_witness9InterpreterSpokenLanguage"] = (
-            "(size(witness9InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness9InterpreterSpokenLanguage), 0) = 0)"
         )
         checks["valid_witness10InterpreterSpokenLanguage"] = (
-            "(size(witness10InterpreterSpokenLanguage) = 0)"
+            "(COALESCE(size(witness10InterpreterSpokenLanguage), 0) = 0)"
         )
 
         checks["valid_listCaseHearingLength"] = ("""
         (
             (
-                CAST(roundedTimeEstimate AS STRING) <=> CAST(listCaseHearingLength AS STRING) 
-                AND CaseStatus_dec IN (37,38)
-                AND CAST(roundedTimeEstimate AS INT) IN (30, 60, 90, 120, 150, 180,210, 240, 270, 300, 330, 360)
+                CAST(roundedTimeEstimate AS STRING) <=> CAST(listCaseHearingLength AS STRING)
+                AND CaseStatus_dec IS NOT NULL AND CaseStatus_dec IN (37,38)
+                AND roundedTimeEstimate IS NOT NULL AND CAST(roundedTimeEstimate AS INT) IN (30, 60, 90, 120, 150, 180,210, 240, 270, 300, 330, 360)
             )
             OR
             (
@@ -305,11 +301,11 @@ class prepareForHearingDQRules(DQRulesBase):
                             WHEN StartTime IS NULL THEN '00:00:00.000'
                             ELSE date_format(CAST(StartTime AS timestamp), 'HH:mm:ss.SSS')
                             END)
-                        AND CaseStatus_dec IN (37,38)
+                        AND CaseStatus_dec IS NOT NULL AND CaseStatus_dec IN (37,38)
                 )
                 OR
                 (
-                    (CaseStatus_dec NOT IN (37,38) OR CaseStatus_dec IS NULL) AND roundedTimeEstimate IS NULL
+                    (CaseStatus_dec NOT IN (37,38) OR CaseStatus_dec IS NULL) AND listCaseHearingDate IS NULL
                 )
             )
             """)
@@ -318,7 +314,7 @@ class prepareForHearingDQRules(DQRulesBase):
             """
             (
                 (
-                    listCaseHearingCentre <=> bronze_listCaseHearingCentre AND CaseStatus_dec IN (37,38) 
+                    listCaseHearingCentre <=> bronze_listCaseHearingCentre AND CaseStatus_dec IS NOT NULL AND CaseStatus_dec IN (37,38)
                 )
                 OR
                 (
@@ -331,7 +327,7 @@ class prepareForHearingDQRules(DQRulesBase):
             """
             (
                 (
-                    listCaseHearingCentreAddress <=> bronze_listCaseHearingCentreAddress AND CaseStatus_dec IN (37,38)
+                    listCaseHearingCentreAddress <=> bronze_listCaseHearingCentreAddress AND CaseStatus_dec IS NOT NULL AND CaseStatus_dec IN (37,38)
                 )
                 OR
                 (
@@ -344,11 +340,11 @@ class prepareForHearingDQRules(DQRulesBase):
 
     def get_checks_document(self, checks={}):
         checks["valid_hearingDocuments"] = (
-            "(size(hearingDocuments) = 0) "
+            "(COALESCE(size(hearingDocuments), 0) = 0) "
         )
 
         checks["valid_letterBundleDocuments"] = (
-            "(size(letterBundleDocuments) = 0) "
+            "(COALESCE(size(letterBundleDocuments), 0) = 0) "
         )
 
         return checks

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/remitted_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/remitted_dq_rules.py
@@ -22,7 +22,7 @@ class remittedDQRules(DQRulesBase):
             """
             (
                 (
-                    CaseStatus_decb = 39 AND 
+                    CaseStatus_decb <=> 39 AND
                     (allocatedJudge <=> concat(Adj_Title, ' ', Adj_Forenames, ' ', Adj_Surname))
                 )
                 OR
@@ -37,7 +37,7 @@ class remittedDQRules(DQRulesBase):
             """
             (
                 (
-                    CaseStatus_decb = 39 AND 
+                    CaseStatus_decb <=> 39 AND
                     (allocatedJudgeEdit <=> concat(Adj_Title, ' ', Adj_Forenames, ' ', Adj_Surname))
                 )
                 OR
@@ -56,16 +56,22 @@ class remittedDQRules(DQRulesBase):
 
         checks["valid_courtReferenceNumber"] = ("""
         (
-            courtReferenceNumber = "This is a migrated ARIA case. Please refer to the documents."
+            courtReferenceNumber <=> "This is a migrated ARIA case. Please refer to the documents."
         )
         """)
 
         checks["valid_appealRemittedDate"] = (
             """
             (
-                (CaseStatus_rem IN (42, 43, 44) AND Outcome_rem = 86)
-                AND
-                appealRemittedDate <=> date_format(CAST(DecisionDate_rem AS timestamp), 'yyyy-MM-dd')
+                (
+                    CaseStatus_rem IS NOT NULL AND CaseStatus_rem IN (42, 43, 44) AND Outcome_rem <=> 86
+                    AND appealRemittedDate <=> date_format(CAST(DecisionDate_rem AS timestamp), 'yyyy-MM-dd')
+                )
+                OR
+                (
+                    (CaseStatus_rem IS NULL OR CaseStatus_rem NOT IN (42, 43, 44) OR NOT (Outcome_rem <=> 86))
+                    AND appealRemittedDate IS NULL
+                )
             )
             """)
 
@@ -74,8 +80,8 @@ class remittedDQRules(DQRulesBase):
 
     def get_checks_document(self, checks={}):
         
-        checks["valid_remittalDocuments"] = ("(size(remittalDocuments) = 0) ")
-        checks["valid_uploadOtherRemittalDocs"] = ("(size(uploadOtherRemittalDocs) = 0) ")
+        checks["valid_remittalDocuments"] = ("(COALESCE(size(remittalDocuments), 0) = 0) ")
+        checks["valid_uploadOtherRemittalDocs"] = ("(COALESCE(size(uploadOtherRemittalDocs), 0) = 0) ")
         return checks
 
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/paymentPending.py
@@ -1932,6 +1932,7 @@ def appellantDetails(silver_m1, silver_m2, silver_c, bronze_countryFromAddress, 
 def cleanReferenceNumber(ref):
     import re
     """
+    Note GWF prefixed references will populate the gwfReferenceNumber field instead. This must be 9 digits but keep the GWF prefix.
     1. Handling Short Reference Numbers e.g., "12345" -> "000012345"
     2. Handling SHEF references e.g., "SHEF1/1234567" -> "001234567"
     3. Handling UKPLa/UKVS reference formats e.g., "UKPLA/123456" -> "000123456"
@@ -1948,11 +1949,11 @@ def cleanReferenceNumber(ref):
     if ref is None or ref == '' or ref.strip().upper() == 'NULL':
         return None
 
-    stripped_ref = ref.strip()
-    if stripped_ref.upper().startswith("GWF"):
-        remainder = stripped_ref[3:]
-        cleaned_remainder = re.sub(r"\D", "", remainder)
-        return "GWF" + cleaned_remainder
+    prefix = ""
+    ref = ref.strip()
+    if ref.upper().startswith("GWF"):
+        prefix = "GWF"
+        ref = ref[3:]
 
     if len(ref) > 9 and len(ref) < 16:
         no_letters = re.sub(r"[a-zA-Z]", "", ref)
@@ -1960,51 +1961,31 @@ def cleanReferenceNumber(ref):
 
         if len(parts) == 2:
             left, right = parts
-            right = right.lstrip("0")
-            combined = left + right
-            return combined.rjust(9, '0')
+            combined = left + right.lstrip("0")
         else:
             combined = "".join(parts)
-            return combined.rjust(9, '0')
 
-        digits_only = re.sub(r"\D", "", combined)
-        return digits_only.rjust(9, '0')
+        return prefix + combined.rjust(9, '0')
 
     if len(ref) < 9:
         digits_only = re.sub(r"\D", "", ref)
-        return digits_only.rjust(9, '0')
-    
+        return prefix + digits_only.rjust(9, '0')
+
     if ref.startswith("SHEF") and "/" in ref:
-        return ref.split("/", 1)[1].rjust(9, '0')
-    
+        return prefix + ref.split("/", 1)[1].rjust(9, '0')
+
     if ref.startswith(('UKPLA' or 'UKVS')) and "/" in ref:
-        return ref.split("/", 1)[1].rjust(9, '0')
-    
+        return prefix + ref.split("/", 1)[1].rjust(9, '0')
+
     match = re.match(r"^.*/(\d+)$", ref)
     if match:
-        return match.group(1).rjust(9, '0')
-    
+        return prefix + match.group(1).rjust(9, '0')
+
     no_special_characters = re.sub(r"\D", "", ref)
     if no_special_characters:
-        return no_special_characters.rjust(9, '0')
+        return prefix + no_special_characters.rjust(9, '0')
 
-    if len(ref) > 9 and len(ref) < 16:
-        no_letters = re.sub(r"[a-zA-Z]", "", ref)
-        parts = no_letters.rsplit("/", 1)
-
-        if len(parts) == 2:
-            left, right = parts
-            right = right.lstrip("0")
-            combined = left + right
-            return combined.rjust(9, '0')
-        else:
-            combined = "".join(parts)
-            return combined.rjust(9, '0')
-
-        digits_only = re.sub(r"\D", "", combined)
-        return digits_only.rjust(9, '0')
-    
-    return ref
+    return prefix + ref
 
 # Register the cleaning function as a Spark UDF
 cleanReferenceNumberUDF = udf(cleanReferenceNumber, StringType())

--- a/tests/active/paymentPending/homeOffice_test.py
+++ b/tests/active/paymentPending/homeOffice_test.py
@@ -23,13 +23,14 @@ def homeOfficeDetails_outputs(spark):
         T.StructField("dv_CCDAppealType", T.StringType(), True),
     ])
 
-    m1_data = [    
+    m1_data = [
         ("EA/06826/2022", "LR",  "A", date(2022, 6, 30), None,"RP"),
         ("EA/09676/2022", "LR",  "A", date(2020, 2, 15), None,"RP"),
         ("EA/00591/2025", "LR",  "A", date(2022, 9, 5),  None,"RP"),
         ("EA/00441/2025", "AIP", "B", date(2025, 2, 12), None,"PA"),
         ("HU/00512/2025", "LR",  "A", date(2024, 7, 11), "R1277473","PA"),
         ("HU/02151/2024", "LR",  "A", None, None,"PA"),
+        ("EA/00777/2025", "LR",  "A", date(2023, 4, 1),  None,"RP"),
     ]
 
     m2_schema = T.StructType([
@@ -56,6 +57,8 @@ def homeOfficeDetails_outputs(spark):
         ("HU/00512/2025", None,           None, None, None, None, None, None, None, None, "SW1A 1AA"),
         # no DateOfApplicationDecision → all date fields null regardless
         ("HU/02151/2024", "XXXXXXXXXXXX", None, None, None, None, None, None, None, None, None),
+        # OOC case with a short (6-digit) GWF reference
+        ("EA/00777/2025", "XXXXXX",       None, None, None, None, None, None, None, None, None),
     ]
 
     silver_c_schema = T.StructType([
@@ -86,6 +89,10 @@ def homeOfficeDetails_outputs(spark):
     ("HU/00512/2025", 31, "paymentPending"),
     ("HU/00512/2025", 37, "paymentPending"),
     ("HU/00512/2025", 39, "paymentPending"),
+
+    ("EA/00777/2025", 11, "paymentPending"),
+    ("EA/00777/2025", 38, "paymentPending"),
+    ("EA/00777/2025", 47, "paymentPending"),
     ]
 
     bronze_HORef_schema = T.StructType([
@@ -94,7 +101,12 @@ def homeOfficeDetails_outputs(spark):
         T.StructField("FCONumber", T.StringType(), True),
     ])
 
-    bronze_HORef_data = [("EA/09676/2022", "GWF063622668", "338224"), ("EA/06826/2022", "GWF061121374", "253601"),]
+    bronze_HORef_data = [
+        ("EA/09676/2022", "GWF063622668", "338224"),
+        ("EA/06826/2022", "GWF061121374", "253601"),
+        # Short (6-digit) GWF reference → should be zero-padded to 9 digits, prefix kept
+        ("EA/00777/2025", "GWF123456", None),
+    ]
 
     silver_m1 = spark.createDataFrame(m1_data, m1_schema)
     silver_m2 = spark.createDataFrame(m2_data, m2_schema)
@@ -156,6 +168,15 @@ def test_category_38_without_gwf_reference(homeOfficeDetails_outputs):
         dateEntryClearanceDecision=None,
         homeOfficeReferenceNumber='999999999',
         gwfReferenceNumber=None,
+    )
+
+def test_category_38_with_short_gwf_reference(homeOfficeDetails_outputs):
+    row = homeOfficeDetails_outputs["EA/00777/2025"]
+
+    assert_equals(
+        row,
+        homeOfficeReferenceNumber=None,
+        gwfReferenceNumber="GWF000123456",
     )
 
 def test_no_relevant_category_ids(homeOfficeDetails_outputs):


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ARIADM-2317
Made listCaseHearingDate mandatory in the DQ (except for ended state which is conditional).

https://tools.hmcts.net/jira/browse/ARIADM-2349
Also fixed the GWF reference number cleansing to prepend 0's to a shorter number.

https://tools.hmcts.net/jira/browse/ARIADM-2297
DQ Rule fix patterns:

- = (Standard equality, nulls return NULL) to <=> (Null safe equality. Nulls are treated as FALSE)
- != (standard not equals) to <=> wrapped in a NOT clause. This is because !<=> is not valid syntax, so we wrap the statement instead in a NOT.
- IS NOT NULL prepended to all IN clauses. When field is null, null IN returns NULL. The IS NOT NULL catches this before and returns FALSE.
- CASE WHEN blocks to always have an ELSE condition. If it didn't, added a default ELSE FALSE to the end. Otherwise if no conditions match, the rule just falls through and if no other catch will return NULL.
- Wrapped all size clauses in a COALESCE with a default of 0 if no non-null values. size(null) returns NULL, so the COALESCE treats it as a size of 0.
- COALESCE array_contains checks with a default empty array in case the array is null.
- to_json wrapped on ARRAY comparisons that aren't done via array_contains, to avoid data type mismatch issues when the parser can't determine the array type due to only having NULL values.
