### PR TITLE
ARIADM-2352 remissionDecision update

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/appealSubmitted.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/appealSubmitted.py
@@ -377,7 +377,11 @@ def remissionTypes(silver_m1, bronze_remission_lookup_df, silver_m4):
             ).when(
                 conditions_all & (
                     (col("PaymentRemissionGranted") == 2)
-                    | (((col("PaymentRemissionGranted") == 0) | col("PaymentRemissionGranted").isNull()) & (col("has_type5_txn").isNull() | (col("has_type5_txn") == False)))
+                    | (
+                        (col("dv_CCDAppealType") != "PA")
+                        & ((col("PaymentRemissionGranted") == 0) | col("PaymentRemissionGranted").isNull())
+                        & (col("has_type5_txn").isNull() | (col("has_type5_txn") == False))
+                    )
                 ),
                 lit("rejected"),
             ),
@@ -393,7 +397,11 @@ def remissionTypes(silver_m1, bronze_remission_lookup_df, silver_m4):
             ).when(
                 conditions_all & (
                     (col("PaymentRemissionGranted") == 2)
-                    | (((col("PaymentRemissionGranted") == 0) | col("PaymentRemissionGranted").isNull()) & (col("has_type5_txn").isNull() | (col("has_type5_txn") == False)))
+                    | (
+                        (col("dv_CCDAppealType") != "PA")
+                        & ((col("PaymentRemissionGranted") == 0) | col("PaymentRemissionGranted").isNull())
+                        & (col("has_type5_txn").isNull() | (col("has_type5_txn") == False))
+                    )
                 ),
                 lit("This is a migrated case. The remission was rejected."),
             ),

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/appealSubmitted_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/appealSubmitted_dq_rules.py
@@ -267,11 +267,19 @@ class appealSubmittedDQRules(DQRulesBase):
                             (
                                 PaymentRemissionGranted <=> 2
                                 OR (
-                                    (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
+                                    NOT (dv_CCDAppealType <=> 'PA')
+                                    AND (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
                                     AND COALESCE(SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 5)), 0) = 0
                                 )
                             )
                             AND remissionDecision <=> 'rejected'
+                        )
+                        OR
+                        (
+                            dv_CCDAppealType <=> 'PA'
+                            AND (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
+                            AND COALESCE(SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 5)), 0) = 0
+                            AND remissionDecision IS NULL
                         )
                     )
                 )
@@ -304,11 +312,19 @@ class appealSubmittedDQRules(DQRulesBase):
                             (
                                 PaymentRemissionGranted <=> 2
                                 OR (
-                                    (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
+                                    NOT (dv_CCDAppealType <=> 'PA')
+                                    AND (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
                                     AND COALESCE(SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 5)), 0) = 0
                                 )
                             )
                             AND remissionDecisionReason <=> 'This is a migrated case. The remission was rejected.'
+                        )
+                        OR
+                        (
+                            dv_CCDAppealType <=> 'PA'
+                            AND (PaymentRemissionGranted IS NULL OR PaymentRemissionGranted = 0)
+                            AND COALESCE(SIZE(FILTER(valid_transactionList, x -> x.TransactionTypeId = 5)), 0) = 0
+                            AND remissionDecisionReason IS NULL
                         )
                     )
                 )

--- a/tests/active/appealSubmitted/aps_remissionType_test.py
+++ b/tests/active/appealSubmitted/aps_remissionType_test.py
@@ -63,7 +63,7 @@ class TestAppealSubmittedRemissionType:
 
     def test_remissionDecision(self, spark):
         with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.remissionTypes.return_value = self.payment_pending_df(spark, 11)
+            PP.remissionTypes.return_value = self.payment_pending_df(spark, 14)
 
             m1_data = [
                 ("1", "EA", "AIP", 1, "protection", None, None, None, None, None),  # EA, granted=1 → approved
@@ -77,6 +77,9 @@ class TestAppealSubmittedRemissionType:
                 ("9", "EA", "AIP", None, "protection", None, None, None, None, None),  # granted=NULL, has type5 txn → approved
                 ("10", "EU", "LR", 0, "protection", None, None, None, None, None),  # granted=0, no type5 txn → rejected
                 ("11", "HU", "AIP", None, "protection", None, None, None, None, None),  # granted=NULL, no type5 txn → rejected
+                ("12", "PA", "LR", 0, "protection", None, None, None, None, None),  # PA, granted=0, no type5 txn → None
+                ("13", "PA", "LR", None, "protection", None, None, None, None, None),  # PA, granted=NULL, no type5 txn → None
+                ("14", "PA", "LR", 2, "protection", None, None, None, None, None),  # PA, granted=2 → rejected (unchanged)
             ]
 
             m4_data = [
@@ -101,10 +104,13 @@ class TestAppealSubmittedRemissionType:
             assert resultList[8][0] == "approved"  # case 9 (granted=NULL, has type5)
             assert resultList[9][0] == "rejected"  # case 10 (granted=0, no type5)
             assert resultList[10][0] == "rejected"  # case 11 (granted=NULL, no type5)
+            assert resultList[11][0] is None  # case 12 (PA, granted=0, no type5)
+            assert resultList[12][0] is None  # case 13 (PA, granted=NULL, no type5)
+            assert resultList[13][0] == "rejected"  # case 14 (PA, granted=2)
 
     def test_remissionDecisionReason(self, spark):
         with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:
-            PP.remissionTypes.return_value = self.payment_pending_df(spark, 11)
+            PP.remissionTypes.return_value = self.payment_pending_df(spark, 14)
 
             m1_data = [
                 ("1", "EA", "AIP", 1, "protection", None, None, None, None, None),  # EA, granted=1 → granted string
@@ -118,6 +124,9 @@ class TestAppealSubmittedRemissionType:
                 ("9", "EA", "AIP", None, "protection", None, None, None, None, None),  # granted=NULL, has type5 txn → granted string
                 ("10", "EU", "LR", 0, "protection", None, None, None, None, None),  # granted=0, no type5 txn → rejected string
                 ("11", "HU", "AIP", None, "protection", None, None, None, None, None),  # granted=NULL, no type5 txn → rejected string
+                ("12", "PA", "LR", 0, "protection", None, None, None, None, None),  # PA, granted=0, no type5 txn → None
+                ("13", "PA", "LR", None, "protection", None, None, None, None, None),  # PA, granted=NULL, no type5 txn → None
+                ("14", "PA", "LR", 2, "protection", None, None, None, None, None),  # PA, granted=2 → rejected string (unchanged)
             ]
 
             m4_data = [
@@ -145,6 +154,9 @@ class TestAppealSubmittedRemissionType:
             assert resultList[8][0] == expected_approved_string  # case 9 (granted=NULL, has type5)
             assert resultList[9][0] == expected_rejected_string  # case 10 (granted=0, no type5)
             assert resultList[10][0] == expected_rejected_string  # case 11 (granted=NULL, no type5)
+            assert resultList[11][0] is None  # case 12 (PA, granted=0, no type5)
+            assert resultList[12][0] is None  # case 13 (PA, granted=NULL, no type5)
+            assert resultList[13][0] == expected_rejected_string  # case 14 (PA, granted=2)
 
     def test_amountRemitted(self, spark):
         with patch('Databricks.ACTIVE.APPEALS.shared_functions.appealSubmitted.PP') as PP:


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ARIADM-2352

Changed false conditional for remissionDecision and remissionDecisionReason in case of PA to be OMITTED

Changes made:

The current logic is for these appealTypes ('EA', 'EU', 'HU', 'PA').

When PaymentRemissionGranted = 1 or when its 0 / NULL and CaseNo has TransactionTypeId = 5, then approved.
When PaymentRemissionGranted = 2 or when its 0 / NULL and CaseNo does not have TransactionTypeId = 5 then rejected.

Changed the second part of the condition (when its 0 / NULL and CaseNo does not have TransactionTypeId = 5), to also check if appealType is not PA. If it is PA, then the condition is skipped, so its not set to rejected. As there is no .otherwise block, the value defaults to None (OMIT).
