### PR TITLE
Inherit homeOfficeDetails from appealSubmitted

### DIFF
--- a/Databricks/ACTIVE/APPEALS/GOLD_AWAITING_EVIDENCE_RESPONDENT_A_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_AWAITING_EVIDENCE_RESPONDENT_A_JSON.ipynb
@@ -382,7 +382,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -596,7 +596,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = PPD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres, bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_AWAITING_EVIDENCE_RESPONDENT_B_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_AWAITING_EVIDENCE_RESPONDENT_B_JSON.ipynb
@@ -379,7 +379,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "#display(df)"
    ]
   },
@@ -592,7 +592,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = PPD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_CASE_UNDER_REVIEW_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_CASE_UNDER_REVIEW_JSON.ipynb
@@ -384,7 +384,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "#display(df)"
    ]
   },
@@ -650,7 +650,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = PPD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_A_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_A_JSON.ipynb
@@ -425,7 +425,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -791,7 +791,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = DA.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_B_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_DECIDED_B_JSON.ipynb
@@ -427,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -808,7 +808,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = DB.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_DECISION_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_DECISION_JSON.ipynb
@@ -428,7 +428,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -743,7 +743,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = D.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_ENDED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_ENDED_JSON.ipynb
@@ -427,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -801,7 +801,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = E.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_FTPA_DECIDED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_FTPA_DECIDED_JSON.ipynb
@@ -428,7 +428,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -780,7 +780,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = FTD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_A_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_A_JSON.ipynb
@@ -426,7 +426,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -778,7 +778,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = FSA.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_B_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_FTPA_SUBMITTED_B_JSON.ipynb
@@ -427,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -779,7 +779,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = FSA.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_LISTING_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_LISTING_JSON.ipynb
@@ -424,7 +424,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -700,7 +700,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = L.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_PREPARE_FOR_HEARING_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_PREPARE_FOR_HEARING_JSON.ipynb
@@ -430,7 +430,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "#display(df)"
    ]
   },
@@ -717,7 +717,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = L.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_REASON_FOR_APPEAL_SUBMITTED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_REASON_FOR_APPEAL_SUBMITTED_JSON.ipynb
@@ -386,7 +386,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -631,7 +631,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1, bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = PPD.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",

--- a/Databricks/ACTIVE/APPEALS/GOLD_REMITTED_JSON.ipynb
+++ b/Databricks/ACTIVE/APPEALS/GOLD_REMITTED_JSON.ipynb
@@ -429,7 +429,7 @@
    },
    "outputs": [],
    "source": [
-    "df, df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "df, df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "# display(df)"
    ]
   },
@@ -803,7 +803,7 @@
     "    legalRepDetails_df, legalRepDetails_df_audit = PP.legalRepDetails(silver_m1,bronze_countryFromAddress)\n",
     "    partyID_df, partyID_df_audit = PPD.partyID(silver_m1, silver_m2, silver_m3, silver_c)\n",
     "    payment_df, payment_df_audit = APS.paymentType(silver_m1, silver_m4)\n",
-    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = PPD.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
+    "    homeOfficeDetails_df, homeOfficeDetails_df_audit = APS.homeOfficeDetails(silver_m1, silver_m2, silver_c, bronze_HORef_cleansing)\n",
     "    remissionTypes_df, remissionTypes_df_audit = APS.remissionTypes(silver_m1, bronze_remissions, silver_m4)\n",
     "    sponsorDetails_df, sponsorDetails_df_audit = PPD.sponsorDetails(silver_m1, silver_m2, silver_c)\n",
     "    general_df, general_df_audit = R.general(silver_m1, silver_m2, silver_m3, silver_h, bronze_hearing_centres, bronze_derive_hearing_centres,bronze_detention_centres)\n",


### PR DESCRIPTION
 instead of paymentPendingDetained for the extra 5 fields in case of PA or RP cases

https://tools.hmcts.net/jira/browse/ARIADM-2357

Changes:

Previous fix raised in https://github.com/hmcts/ARIAMigration-Databrick/pull/1112 for the 5 extra fields were added for appealSubmitted only.
The other states all pulled from paymentPendingDetained instead.
This PR makes everything pull from appealSubmitted (which only adds the extra 5 fields and already pulls from PPD).

There are no further downstream changes to homeOfficeDetails fields so all can safely pull directly from APS instead.