### PR TITLE
Trim more than 2000 chars additionalInstructionsTribunalResponse

### DIFF
--- a/Databricks/ACTIVE/APPEALS/shared_functions/caseUnderReview.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/caseUnderReview.py
@@ -1,4 +1,4 @@
-from pyspark.sql.functions import col, struct, lit, concat, array, trim, concat_ws, when, desc, coalesce, nullif, collect_list, to_date, date_format
+from pyspark.sql.functions import col, struct, lit, concat, array, trim, concat_ws, when, desc, coalesce, nullif, collect_list, to_date, date_format, substring
 from pyspark.sql import functions as F
 from pyspark.sql import Window
 from . import AwaitingEvidenceRespondant_b as AERb
@@ -93,7 +93,7 @@ def hearingResponse(silver_m1, silver_m3, silver_m6):
                                 when(col("Notes").isNull(), "N/A").otherwise(col("Notes"))
                     ).withColumn("additionalInstructionsTribunalResponse",
                                 when(col("CaseStatus").eqNullSafe(26),
-                                    concat(
+                                    substring(concat(
                                         lit("Listed details from ARIA: "),
                                         lit("\nHearing Centre: "), coalesce(col("Hearing Centre"), lit("N/A")),
                                         lit("\nHearing Date: "), coalesce(col("Hearing Date"), lit("N/A")),
@@ -108,7 +108,7 @@ def hearingResponse(silver_m1, silver_m3, silver_m6):
                                         lit("\nRequired/Incompatible Judicial Officers: "),
                                         coalesce(col("Required/Incompatible Judicial Officers"), lit("")),
                                         lit("\nNotes: "), coalesce(col("Notes"), lit("N/A"))
-                                    )
+                                    ), 1, 2000)
                                 )
                     )
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ended_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/ended_dq_rules.py
@@ -1451,19 +1451,24 @@ class endedDQRules(DQRulesBase):
                     OR
                     (
                         LENGTH(additionalInstructionsTribunalResponse) <= 2000 AND
-                        additionalInstructionsTribunalResponse LIKE 'Listed details from ARIA: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nHearing Centre: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nHearing Date: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nHearing Type: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nCourt: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nList Type: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nList Start Time: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nJudge First Tier: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nCourt Clerk / Usher: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nStart Time: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nEstimated Duration: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nRequired/Incompatible Judicial Officers: %' AND
-                        additionalInstructionsTribunalResponse LIKE '%\\nNotes: %'
+                        (
+                            LENGTH(additionalInstructionsTribunalResponse) = 2000 OR
+                            (
+                                additionalInstructionsTribunalResponse LIKE 'Listed details from ARIA: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nHearing Centre: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nHearing Date: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nHearing Type: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nCourt: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nList Type: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nList Start Time: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nJudge First Tier: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nCourt Clerk / Usher: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nStart Time: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nEstimated Duration: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nRequired/Incompatible Judicial Officers: %' AND
+                                additionalInstructionsTribunalResponse LIKE '%\\nNotes: %'
+                            )
+                        )
                     )
                 )
                 ELSE

--- a/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/dq_rules/prepareforhearing_dq_rules.py
@@ -108,19 +108,24 @@ class prepareForHearingDQRules(DQRulesBase):
             additionalInstructionsTribunalResponse IS NULL OR
             (
                 LENGTH(additionalInstructionsTribunalResponse) <= 2000 AND
-                additionalInstructionsTribunalResponse LIKE 'Listed details from ARIA: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nHearing Centre: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nHearing Date: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nHearing Type: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nCourt: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nList Type: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nList Start Time: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nJudge First Tier: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nCourt Clerk / Usher: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nStart Time: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nEstimated Duration: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nRequired/Incompatible Judicial Officers: %' AND
-                additionalInstructionsTribunalResponse LIKE '%\\nNotes: %'
+                (
+                    LENGTH(additionalInstructionsTribunalResponse) = 2000 OR
+                    (
+                        additionalInstructionsTribunalResponse LIKE 'Listed details from ARIA: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nHearing Centre: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nHearing Date: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nHearing Type: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nCourt: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nList Type: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nList Start Time: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nJudge First Tier: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nCourt Clerk / Usher: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nStart Time: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nEstimated Duration: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nRequired/Incompatible Judicial Officers: %' AND
+                        additionalInstructionsTribunalResponse LIKE '%\\nNotes: %'
+                    )
+                )
             )
         """)
 

--- a/Databricks/ACTIVE/APPEALS/shared_functions/prepareForHearing.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/prepareForHearing.py
@@ -4,7 +4,7 @@ from . import listing as L
 
 from pyspark.sql.functions import (
     col, when, lit, array, struct, collect_list,
-    row_number, nullif, coalesce, concat_ws, concat, trim, map_from_arrays, to_date, date_format
+    row_number, nullif, coalesce, concat_ws, concat, trim, map_from_arrays, to_date, date_format, substring
 )
 
 
@@ -85,7 +85,7 @@ def hearingResponse(silver_m1, silver_m3, silver_m6):
                     ).withColumn("Notes",
                                 when(col("Notes").isNull(), "N/A").otherwise(col("Notes"))
                     ).withColumn("additionalInstructionsTribunalResponse",
-                                concat(
+                                substring(concat(
                                     lit("Listed details from ARIA: "),
                                     lit("\nHearing Centre: "), coalesce(col("Hearing Centre"), lit("N/A")),
                                     lit("\nHearing Date: "), coalesce(col("Hearing Date"), lit("N/A")),
@@ -100,7 +100,7 @@ def hearingResponse(silver_m1, silver_m3, silver_m6):
                                     lit("\nRequired/Incompatible Judicial Officers: "),
                                     coalesce(col("Required/Incompatible Judicial Officers"), lit("")),
                                     lit("\nNotes: "), coalesce(col("Notes"), lit("N/A"))
-                            )
+                            ), 1, 2000)
                     )
     
     content_df = final_df.select(col("CaseNo"), col("additionalInstructionsTribunalResponse"), col("isAppealSuitableToFloat"), col("ListTypeId"))

--- a/Databricks/ACTIVE/APPEALS/shared_functions/reasonsForAppealSubmitted.py
+++ b/Databricks/ACTIVE/APPEALS/shared_functions/reasonsForAppealSubmitted.py
@@ -1,6 +1,6 @@
 from pyspark.sql.functions import (
     col, when, lit, array, struct, collect_list,
-    coalesce, concat_ws, concat, trim, nullif, desc, to_date, date_format
+    coalesce, concat_ws, concat, trim, nullif, desc, to_date, date_format, substring
 )
 from pyspark.sql import functions as F
 from pyspark.sql import Window
@@ -78,7 +78,7 @@ def hearingResponse(silver_m1, silver_m3, silver_m6):
                                 when(col("Notes").isNull(), "N/A").otherwise(col("Notes"))
                     ).withColumn("additionalInstructionsTribunalResponse",
                                 when(col("CaseStatus").eqNullSafe(26),
-                                    concat(
+                                    substring(concat(
                                         lit("Listed details from ARIA: "),
                                         lit("\nHearing Centre: "), coalesce(col("Hearing Centre"), lit("N/A")),
                                         lit("\nHearing Date: "), coalesce(col("Hearing Date"), lit("N/A")),
@@ -93,7 +93,7 @@ def hearingResponse(silver_m1, silver_m3, silver_m6):
                                         lit("\nRequired/Incompatible Judicial Officers: "),
                                         coalesce(col("Required/Incompatible Judicial Officers"), lit("")),
                                         lit("\nNotes: "), coalesce(col("Notes"), lit("N/A"))
-                                    )
+                                    ), 1, 2000)
                                 )
                     )
     additionalInstructionsTribunalResponse_schema_dict = {

--- a/tests/active/caseUnderReview/cur_hearingResponse_test.py
+++ b/tests/active/caseUnderReview/cur_hearingResponse_test.py
@@ -212,7 +212,7 @@ class TestCaseUnderReviewHearingResponse:
             JudgeLastName3 JudgeFirstName3 ( Judge3 ) : Not Required
             Notes: Notes\
         """).strip()
-        untruncated_response_9 = (
+        untruncated_response = (
             "Listed details from ARIA: \n"
             "Hearing Centre: HearingCentre\n"
             "Hearing Date: 2000-01-01\n"
@@ -227,7 +227,7 @@ class TestCaseUnderReviewHearingResponse:
             "Required/Incompatible Judicial Officers: \n"
             "Notes: " + "N" * 2500
         )
-        assert len(untruncated_response_9) > 2000
-        assert resultList[6][0] == untruncated_response_9[:2000]  # CaseNo 9 - response truncated to 2000 chars
+        assert len(untruncated_response) > 2000
+        assert resultList[6][0] == untruncated_response[:2000]  # CaseNo 9 - response truncated to 2000 chars
         assert len(resultList[6][0]) == 2000
         assert len(resultList) == 7  # 2 excluded (case 5: Outcome != 0; case 8: AIP representation); 7 remain, 2 with NULL response (CaseNo 2, 3: CaseStatus 37/38)

--- a/tests/active/caseUnderReview/cur_hearingResponse_test.py
+++ b/tests/active/caseUnderReview/cur_hearingResponse_test.py
@@ -125,8 +125,15 @@ class TestCaseUnderReviewHearingResponse:
                 "8", 1, 26, 0, "HearingCentre", "2000-01-01", "Type", "Court",
                 "List", "10:00", "10", "Notes", None, None, None, None, None,
                 None, None, None, None, None, None, None
+            ),
+            (  # CaseStatus 26 and Outcome == 0 - valid - Notes long enough to push response over 2000 chars
+                "9", 1, 26, 0, "HearingCentre", "2000-01-01", "Type", "Court",
+                "List", "10:00", "10", "N" * 2500, None, None, None, None, None,
+                None, None, None, None, None, None, None
             )
         ], self.SILVER_M3_SCHEMA)
+
+        silver_m1 = silver_m1.union(spark.createDataFrame([("9", "LR", "appeal")], self.SILVER_M1_SCHEMA))
 
         silver_m6 = spark.createDataFrame([
             ("6", "1", "JudgeLastName", "JudgeFirstName", "Judge"),
@@ -205,4 +212,22 @@ class TestCaseUnderReviewHearingResponse:
             JudgeLastName3 JudgeFirstName3 ( Judge3 ) : Not Required
             Notes: Notes\
         """).strip()
-        assert len(resultList) == 6  # 2 excluded (case 5: Outcome != 0; case 8: AIP representation); 6 remain, 2 with NULL response (CaseNo 2, 3: CaseStatus 37/38)
+        untruncated_response_9 = (
+            "Listed details from ARIA: \n"
+            "Hearing Centre: HearingCentre\n"
+            "Hearing Date: 2000-01-01\n"
+            "Hearing Type: Type\n"
+            "Court: Court\n"
+            "List Type: List\n"
+            "List Start Time: 10:00:00\n"
+            "Judge First Tier: \n"
+            "Court Clerk / Usher: N/A\n"
+            "Start Time: 10:00:00\n"
+            "Estimated Duration: 10\n"
+            "Required/Incompatible Judicial Officers: \n"
+            "Notes: " + "N" * 2500
+        )
+        assert len(untruncated_response_9) > 2000
+        assert resultList[6][0] == untruncated_response_9[:2000]  # CaseNo 9 - response truncated to 2000 chars
+        assert len(resultList[6][0]) == 2000
+        assert len(resultList) == 7  # 2 excluded (case 5: Outcome != 0; case 8: AIP representation); 7 remain, 2 with NULL response (CaseNo 2, 3: CaseStatus 37/38)

--- a/tests/active/prepareforhearing/hearingResponse_test.py
+++ b/tests/active/prepareforhearing/hearingResponse_test.py
@@ -42,7 +42,8 @@ def hearingResponse_outputs(spark):
         ("CASE008", "AIP", "FT", None, 0, 0, False, None),    # For m3 conditional tests - Additional Language Spoken + Sign Manual
         ("CASE009", "AIP", "FT", None, 0, 0, None, 2),    # For m3 conditional tests - Additional Language Sign + Sign
         ("CASE010", "AIP", "FT", None, 0, 0, None, 2),   # For m3 conditional tests - Additional Language Sign + Spoken Manual
-        ("CASE011", "AIP", "FT", None, 0, 0, True, 61)    # For m3 conditional tests - Additional Language Sign + Sign Manual
+        ("CASE011", "AIP", "FT", None, 0, 0, True, 61),    # For m3 conditional tests - Additional Language Sign + Sign Manual
+        ("CASE012", "AIP", "FTPA", None, 0, 1, True, 1)    # For additionalInstructionsTribunalResponse truncation test
         ]
 
     m3_schema = T.StructType([
@@ -73,15 +74,18 @@ def hearingResponse_outputs(spark):
     ])
 
 
+    long_notes = "N" * 2500  # long enough to push additionalInstructionsTribunalResponse past the 2000 char limit
+
     m3_data = [
-        ("CASE001", 1, 37, 180, "LOC001","CC_Sur", "CC_Fore", "CC_T",5,"Standard",date(2023,10,1),"HearingType","CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T","xxxx"),  
+        ("CASE001", 1, 37, 180, "LOC001","CC_Sur", "CC_Fore", "CC_T",5,"Standard",date(2023,10,1),"HearingType","CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T","xxxx"),
         ("CASE002", 2, 37, 60, "LOC002", None, "CC_Fore", "CC_T",5,"Urgent",date(2023,10,1),None,"CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T","Noxxxxtes"),  
         ("CASE003", 1, 38, 240, "LOC003", "CC_Sur", None, "CC_T",5,"Special",date(2023,10,1),"HearingType","CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T","Notes"),  
         ("CASE004", 1, 38, 360, "LOC004", "CC_Sur", "CC_Fore", None,5,"Standard",date(2023,10,1),None,"CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name",None,"Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T","Notes"),   
         ("CASE005", 1, 37, None, "LOC005", None, None, "CC_T",5,"Urgent",date(2023,10,1),"HearingType",None,datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T",None),   
         ("CASE006", 1, 37, 30, "LOC006",None, None, None,None,"Special",date(2023,10,1),"HearingType","CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T","Notes"),   
         ("CASE007", 1, 38, None, "LOC007", "CC_Sur", "CC_Fore", "CC_T",2,"Standard",date(2023,10,1),"HearingType","CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T","Notes"),
-        ("CASE008", 1, 38, 45, "LOC008", "CC_Sur", "CC_Fore", "CC_T",1,"Urgent",date(2023,10,1),"HearingType","CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T","Notes")
+        ("CASE008", 1, 38, 45, "LOC008", "CC_Sur", "CC_Fore", "CC_T",1,"Urgent",date(2023,10,1),"HearingType","CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T","Notes"),
+        ("CASE012", 1, 37, 180, "LOC001","CC_Sur", "CC_Fore", "CC_T",5,"Standard",date(2023,10,1),"HearingType","CourtName",datetime(2023,10,1,10,0,0),"Jud_S1_Name","Jud_F1_Name","Judge1_T","Jud_S2_Name","Jud_F2_Name","Judge2_T","Jud_S3_Name","Jud_F3_Name","Judge3_T",long_notes)
     ]
  
 
@@ -115,8 +119,9 @@ def hearingResponse_outputs(spark):
         ("CASE005", 0, None,None,"Judge_T"),   # Additional Sign Manual Language (to Spoken + Sign Manual)
         ("CASE006", 0, None,None,None),   # Additional Sign Language (to Sign + Sign Manual)
         ("CASE007", None,  "Jud_S_Name","Jud_F_Name","Judge_T"),  # Additional Manual Language Entry (to Sign + Spoken Manual)
-        ("CASE008", None, "Jud_S_Name","Jud_F_Name","Judge_T")   # Additional Sign Manual Language (to Sign + Sign Manual)
-        ] 
+        ("CASE008", None, "Jud_S_Name","Jud_F_Name","Judge_T"),   # Additional Sign Manual Language (to Sign + Sign Manual)
+        ("CASE012", 1,  "Jud_S_Name","Jud_F_Name","Judge_T")   # For additionalInstructionsTribunalResponse truncation test
+        ]
     
 
     df_m1 =  spark.createDataFrame(m1_data, m1_schema)
@@ -317,5 +322,16 @@ def test_additionalInstructionsTribunalResponse(spark,hearingResponse_outputs):
     assert results["CASE006"]["additionalInstructionsTribunalResponse"] == 'Listed details from ARIA: \nHearing Centre: LOC006\nHearing Date: 2023-10-01\nHearing Type: HearingType\nCourt: CourtName\nList Type: Special\nList Start Time: 10:00:00\nJudge First Tier: Jud_S1_Name Jud_F1_Name (Judge1_T) Jud_S2_Name Jud_F2_Name (Judge2_T) Jud_S3_Name Jud_F3_Name (Judge3_T)\nCourt Clerk / Usher: N/A\nStart Time: 10:00:00\nEstimated Duration: 30\nRequired/Incompatible Judicial Officers: \n: Not Required\nNotes: Notes'
     assert results["CASE007"]["additionalInstructionsTribunalResponse"] == 'Listed details from ARIA: \nHearing Centre: LOC007\nHearing Date: 2023-10-01\nHearing Type: HearingType\nCourt: CourtName\nList Type: Standard\nList Start Time: 10:00:00\nJudge First Tier: Jud_S1_Name Jud_F1_Name (Judge1_T) Jud_S2_Name Jud_F2_Name (Judge2_T) Jud_S3_Name Jud_F3_Name (Judge3_T)\nCourt Clerk / Usher: CC_Sur CC_Fore (CC_T)\nStart Time: 10:00:00\nEstimated Duration: N/A\nRequired/Incompatible Judicial Officers: \nJud_S_Name Jud_F_Name ( Judge_T )\nNotes: Notes'
     assert results["CASE008"]["additionalInstructionsTribunalResponse"] == 'Listed details from ARIA: \nHearing Centre: LOC008\nHearing Date: 2023-10-01\nHearing Type: HearingType\nCourt: CourtName\nList Type: Urgent\nList Start Time: 10:00:00\nJudge First Tier: Jud_S1_Name Jud_F1_Name (Judge1_T) Jud_S2_Name Jud_F2_Name (Judge2_T) Jud_S3_Name Jud_F3_Name (Judge3_T)\nCourt Clerk / Usher: CC_Sur CC_Fore (CC_T)\nStart Time: 10:00:00\nEstimated Duration: 45\nRequired/Incompatible Judicial Officers: \nJud_S_Name Jud_F_Name ( Judge_T )\nNotes: Notes'
+
+def test_additionalInstructionsTribunalResponse_truncated_over_2000_chars(spark,hearingResponse_outputs):
+
+    results = hearingResponse_outputs
+
+    long_notes = "N" * 2500
+    untruncated = 'Listed details from ARIA: \nHearing Centre: LOC001\nHearing Date: 2023-10-01\nHearing Type: HearingType\nCourt: CourtName\nList Type: Standard\nList Start Time: 10:00:00\nJudge First Tier: Jud_S1_Name Jud_F1_Name (Judge1_T) Jud_S2_Name Jud_F2_Name (Judge2_T) Jud_S3_Name Jud_F3_Name (Judge3_T)\nCourt Clerk / Usher: CC_Sur CC_Fore (CC_T)\nStart Time: 10:00:00\nEstimated Duration: 180\nRequired/Incompatible Judicial Officers: \nJud_S_Name Jud_F_Name ( Judge_T ) : Required\nNotes: ' + long_notes
+
+    assert len(untruncated) > 2000
+    assert results["CASE012"]["additionalInstructionsTribunalResponse"] == untruncated[:2000]
+    assert len(results["CASE012"]["additionalInstructionsTribunalResponse"]) == 2000
 
 

--- a/tests/active/reasonForAppealSubmitted/rfas_hearingResponse_test.py
+++ b/tests/active/reasonForAppealSubmitted/rfas_hearingResponse_test.py
@@ -125,8 +125,15 @@ class TestReasonForAppealSubmittedHearingResponse:
                 "8", 1, 26, 0, "HearingCentre", "2000-01-01", "Type", "Court",
                 "List", "10:00", "10", "Notes", None, None, None, None, None,
                 None, None, None, None, None, None, None
+            ),
+            (  # CaseStatus 26 and Outcome == 0 - valid - Notes long enough to push response over 2000 chars
+                "9", 1, 26, 0, "HearingCentre", "2000-01-01", "Type", "Court",
+                "List", "10:00", "10", "N" * 2500, None, None, None, None, None,
+                None, None, None, None, None, None, None
             )
         ], self.SILVER_M3_SCHEMA)
+
+        silver_m1 = silver_m1.union(spark.createDataFrame([("9", "AIP", "appeal")], self.SILVER_M1_SCHEMA))
 
         silver_m6 = spark.createDataFrame([
             ("6", "1", "JudgeLastName", "JudgeFirstName", "Judge"),
@@ -205,4 +212,22 @@ class TestReasonForAppealSubmittedHearingResponse:
             JudgeLastName3 JudgeFirstName3 ( Judge3 ) : Not Required
             Notes: Notes\
         """).strip()
-        assert len(resultList) == 6  # 2 excluded (case 5: Outcome != 0; case 8: LR representation); 6 remain, 2 with NULL response (CaseNo 2, 3: CaseStatus 37/38)
+        untruncated_response_9 = (
+            "Listed details from ARIA: \n"
+            "Hearing Centre: HearingCentre\n"
+            "Hearing Date: 2000-01-01\n"
+            "Hearing Type: Type\n"
+            "Court: Court\n"
+            "List Type: List\n"
+            "List Start Time: 10:00:00\n"
+            "Judge First Tier: \n"
+            "Court Clerk / Usher: N/A\n"
+            "Start Time: 10:00:00\n"
+            "Estimated Duration: 10\n"
+            "Required/Incompatible Judicial Officers: \n"
+            "Notes: " + "N" * 2500
+        )
+        assert len(untruncated_response_9) > 2000
+        assert resultList[6][0] == untruncated_response_9[:2000]  # CaseNo 9 - response truncated to 2000 chars
+        assert len(resultList[6][0]) == 2000
+        assert len(resultList) == 7  # 2 excluded (case 5: Outcome != 0; case 8: LR representation); 7 remain, 2 with NULL response (CaseNo 2, 3: CaseStatus 37/38)

--- a/tests/active/reasonForAppealSubmitted/rfas_hearingResponse_test.py
+++ b/tests/active/reasonForAppealSubmitted/rfas_hearingResponse_test.py
@@ -212,7 +212,7 @@ class TestReasonForAppealSubmittedHearingResponse:
             JudgeLastName3 JudgeFirstName3 ( Judge3 ) : Not Required
             Notes: Notes\
         """).strip()
-        untruncated_response_9 = (
+        untruncated_response = (
             "Listed details from ARIA: \n"
             "Hearing Centre: HearingCentre\n"
             "Hearing Date: 2000-01-01\n"
@@ -227,7 +227,7 @@ class TestReasonForAppealSubmittedHearingResponse:
             "Required/Incompatible Judicial Officers: \n"
             "Notes: " + "N" * 2500
         )
-        assert len(untruncated_response_9) > 2000
-        assert resultList[6][0] == untruncated_response_9[:2000]  # CaseNo 9 - response truncated to 2000 chars
+        assert len(untruncated_response) > 2000
+        assert resultList[6][0] == untruncated_response[:2000]  # CaseNo 9 - response truncated to 2000 chars
         assert len(resultList[6][0]) == 2000
         assert len(resultList) == 7  # 2 excluded (case 5: Outcome != 0; case 8: LR representation); 7 remain, 2 with NULL response (CaseNo 2, 3: CaseStatus 37/38)


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ARIADM-2270

This ticket wraps the additionalInstructionsTribunalResponse field in a substring of index 1 (this function is 1 index based), to 2000, meaning the field only retains up to 2000 characters (leading).

The DQ rules have been updated to only check for the existence of expected strings if the length is less than 2000, otherwise if the number of characters is greater than 2000, any part of the expected strings could be cut off at some point.